### PR TITLE
설문조사 한글, 영문 분리되어 표시되도록 개선

### DIFF
--- a/Project_Timer.xcodeproj/project.pbxproj
+++ b/Project_Timer.xcodeproj/project.pbxproj
@@ -2019,7 +2019,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = Project_Timer/Project_Timer.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 12;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 2C96RNDN63;
 				"ENABLE_HARDENED_RUNTIME[sdk=macosx*]" = YES;
 				INFOPLIST_FILE = Project_Timer/Info.plist;
@@ -2028,7 +2028,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 7.15;
+				MARKETING_VERSION = 7.15.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.FDEE.TiTi;
 				PRODUCT_NAME = TiTi;
 				SUPPORTS_MACCATALYST = YES;
@@ -2046,7 +2046,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = Project_Timer/Project_Timer.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 12;
+				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 2C96RNDN63;
 				"ENABLE_HARDENED_RUNTIME[sdk=macosx*]" = YES;
 				INFOPLIST_FILE = Project_Timer/Info.plist;
@@ -2055,7 +2055,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 7.15;
+				MARKETING_VERSION = 7.15.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.FDEE.TiTi;
 				PRODUCT_NAME = TiTi;
 				SUPPORTS_MACCATALYST = YES;

--- a/Project_Timer/Network/NetworkURL.swift
+++ b/Project_Timer/Network/NetworkURL.swift
@@ -22,8 +22,14 @@ enum NetworkURL {
         static let domain: String = "https://firestore.googleapis.com/v1/projects/\(projectId)/databases/(default)/documents"
         static let links: String = domain + "/links"
         static let youtubeLink: String = links + "/youtube"
-        static let surveys: String = domain + "/surveys"
         static let lastestVersion: String = domain + "/version/lastestVersion"
+        
+        static var surveys: String {
+            switch Language.currentLanguage {
+            case .ko: return domain + "/surveys"
+            case .en: return domain + "/surveys_eng"
+            }
+        }
         
         static var titifuncs: String {
             switch Language.currentLanguage {


### PR DESCRIPTION
### 개요
- Issue: #88 
- Tech Spec: 없음
- Figma: 없음

---

### 변경사항
- [x] NetworkURL.Firestore.surveys 내에서 Language.currentLanguage 값에 따라 한글용 url, 영문용 url를 반환
