### PR TITLE
Setting 내 로그인하기 추가

### DIFF
--- a/Project_Timer.xcodeproj/project.pbxproj
+++ b/Project_Timer.xcodeproj/project.pbxproj
@@ -247,6 +247,7 @@
 		87E6004B28426EBF008D17B9 /* SettingVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87E6004A28426EBF008D17B9 /* SettingVC.swift */; };
 		87ED9ABD28D1661200186677 /* TasksCircularProgressSwiftUIView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87ED9ABC28D1661200186677 /* TasksCircularProgressSwiftUIView.swift */; };
 		87ED9ABF28D16FC200186677 /* TasksCircularProgressDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87ED9ABE28D16FC200186677 /* TasksCircularProgressDTO.swift */; };
+		87EFD6812AC115DB00C422B1 /* LoginSignupVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87EFD6802AC115DB00C422B1 /* LoginSignupVC.swift */; };
 		87F10930284C4337002E31EA /* TiTiLabHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87F1092F284C4337002E31EA /* TiTiLabHeaderView.swift */; };
 		87F10932284C4367002E31EA /* SurveyCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87F10931284C4367002E31EA /* SurveyCell.swift */; };
 		87F10936284C47A1002E31EA /* SettingTiTiLabVM.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87F10935284C47A1002E31EA /* SettingTiTiLabVM.swift */; };
@@ -527,6 +528,7 @@
 		87E6004A28426EBF008D17B9 /* SettingVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingVC.swift; sourceTree = "<group>"; };
 		87ED9ABC28D1661200186677 /* TasksCircularProgressSwiftUIView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TasksCircularProgressSwiftUIView.swift; sourceTree = "<group>"; };
 		87ED9ABE28D16FC200186677 /* TasksCircularProgressDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TasksCircularProgressDTO.swift; sourceTree = "<group>"; };
+		87EFD6802AC115DB00C422B1 /* LoginSignupVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginSignupVC.swift; sourceTree = "<group>"; };
 		87F1092F284C4337002E31EA /* TiTiLabHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TiTiLabHeaderView.swift; sourceTree = "<group>"; };
 		87F10931284C4367002E31EA /* SurveyCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurveyCell.swift; sourceTree = "<group>"; };
 		87F10935284C47A1002E31EA /* SettingTiTiLabVM.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingTiTiLabVM.swift; sourceTree = "<group>"; };
@@ -772,6 +774,7 @@
 				874F9C342ABFFDE900675A86 /* LoginSelect */,
 				874F9C322ABFFDDF00675A86 /* LoginView.swift */,
 				87B7A5392AC0219B002AFDFE /* SignupNicknameView.swift */,
+				87EFD6802AC115DB00C422B1 /* LoginSignupVC.swift */,
 			);
 			path = LoginSignup;
 			sourceTree = "<group>";
@@ -1691,6 +1694,7 @@
 				878899852894F09600B7F378 /* WeekTimelineView.swift in Sources */,
 				87F1093B284C589A002E31EA /* SettingFunctionsListVM.swift in Sources */,
 				8788997C2894F00000B7F378 /* LogWeekVM.swift in Sources */,
+				87EFD6812AC115DB00C422B1 /* LoginSignupVC.swift in Sources */,
 				873C197828D044CC00E02ADC /* DailyVM.swift in Sources */,
 				879108252838761B005D7B10 /* NetworkStatus.swift in Sources */,
 				87BF666C28F80EA500CD6F19 /* NormalTimeLabelVM.swift in Sources */,

--- a/Project_Timer.xcodeproj/project.pbxproj
+++ b/Project_Timer.xcodeproj/project.pbxproj
@@ -248,6 +248,7 @@
 		87ED9ABD28D1661200186677 /* TasksCircularProgressSwiftUIView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87ED9ABC28D1661200186677 /* TasksCircularProgressSwiftUIView.swift */; };
 		87ED9ABF28D16FC200186677 /* TasksCircularProgressDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87ED9ABE28D16FC200186677 /* TasksCircularProgressDTO.swift */; };
 		87EFD6812AC115DB00C422B1 /* LoginSignupVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87EFD6802AC115DB00C422B1 /* LoginSignupVC.swift */; };
+		87EFD6832AC12C3800C422B1 /* LoginSignupEventListener.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87EFD6822AC12C3800C422B1 /* LoginSignupEventListener.swift */; };
 		87F10930284C4337002E31EA /* TiTiLabHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87F1092F284C4337002E31EA /* TiTiLabHeaderView.swift */; };
 		87F10932284C4367002E31EA /* SurveyCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87F10931284C4367002E31EA /* SurveyCell.swift */; };
 		87F10936284C47A1002E31EA /* SettingTiTiLabVM.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87F10935284C47A1002E31EA /* SettingTiTiLabVM.swift */; };
@@ -529,6 +530,7 @@
 		87ED9ABC28D1661200186677 /* TasksCircularProgressSwiftUIView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TasksCircularProgressSwiftUIView.swift; sourceTree = "<group>"; };
 		87ED9ABE28D16FC200186677 /* TasksCircularProgressDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TasksCircularProgressDTO.swift; sourceTree = "<group>"; };
 		87EFD6802AC115DB00C422B1 /* LoginSignupVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginSignupVC.swift; sourceTree = "<group>"; };
+		87EFD6822AC12C3800C422B1 /* LoginSignupEventListener.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginSignupEventListener.swift; sourceTree = "<group>"; };
 		87F1092F284C4337002E31EA /* TiTiLabHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TiTiLabHeaderView.swift; sourceTree = "<group>"; };
 		87F10931284C4367002E31EA /* SurveyCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurveyCell.swift; sourceTree = "<group>"; };
 		87F10935284C47A1002E31EA /* SettingTiTiLabVM.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingTiTiLabVM.swift; sourceTree = "<group>"; };
@@ -770,11 +772,12 @@
 		874F9C292ABFF4F400675A86 /* LoginSignup */ = {
 			isa = PBXGroup;
 			children = (
+				87EFD6802AC115DB00C422B1 /* LoginSignupVC.swift */,
+				87EFD6822AC12C3800C422B1 /* LoginSignupEventListener.swift */,
 				87B7A53B2AC02202002AFDFE /* LoginSignupRoute.swift */,
 				874F9C342ABFFDE900675A86 /* LoginSelect */,
 				874F9C322ABFFDDF00675A86 /* LoginView.swift */,
 				87B7A5392AC0219B002AFDFE /* SignupNicknameView.swift */,
-				87EFD6802AC115DB00C422B1 /* LoginSignupVC.swift */,
 			);
 			path = LoginSignup;
 			sourceTree = "<group>";
@@ -1687,6 +1690,7 @@
 				879D20812A19E44B00D8A420 /* TargetTimeView.swift in Sources */,
 				87A4704826493D4D007B89D6 /* RecordTimes.swift in Sources */,
 				872C0EE3284AF26A00E8E3F2 /* SettingUpdateHistoryVM.swift in Sources */,
+				87EFD6832AC12C3800C422B1 /* LoginSignupEventListener.swift in Sources */,
 				93A892B124C14D4700F89180 /* CircularProgressView.swift in Sources */,
 				8791C1F427DCD120000D6BA9 /* UserDefaultsManager.swift in Sources */,
 				8765234F28C7964500487BFB /* TotalVM.swift in Sources */,

--- a/Project_Timer/LoginSignup/LoginSelect/LoginSelectView.swift
+++ b/Project_Timer/LoginSignup/LoginSelect/LoginSelectView.swift
@@ -9,6 +9,7 @@
 import SwiftUI
 
 struct LoginSelectView: View {
+    @EnvironmentObject var listener: LoginSignupEventListener
     @State private var navigationPath: [LoginSignupRoute] = []
     
     var body: some View {
@@ -47,12 +48,14 @@ struct LoginSelectView: View {
                     .frame(height: 8)
                 
                 Text("TimerTiTi")
+                    .foregroundStyle(.black)
                     .font(.custom("HGGGothicssiP80g", size: 15))
                 
                 Spacer()
                     .frame(height: 58)
                 
                 Text("#타이머티티")
+                    .foregroundStyle(.black)
                     .font(.custom("HGGGothicssiP80g", size: 33))
                 
                 Spacer()
@@ -66,7 +69,7 @@ struct LoginSelectView: View {
     }
     
     struct ButtonsView: View {
-        @Environment(\.dismiss) private var dismiss
+        @EnvironmentObject var listener: LoginSignupEventListener
         @Binding var navigationPath: [LoginSignupRoute]
         
         var body: some View {
@@ -81,7 +84,7 @@ struct LoginSelectView: View {
                     navigationPath.append(.login)
                 }
                 Button {
-                    dismiss()
+                    listener.dismiss = true
                 } label: {
                     Text("로그인없이 서비스 이용하기")
                         .font(.custom("HGGGothicssiP60g", size: 13))

--- a/Project_Timer/LoginSignup/LoginSignupEventListener.swift
+++ b/Project_Timer/LoginSignup/LoginSignupEventListener.swift
@@ -1,0 +1,14 @@
+//
+//  LoginSignupEventListener.swift
+//  Project_Timer
+//
+//  Created by Kang Minsang on 2023/09/25.
+//  Copyright © 2023 FDEE. All rights reserved.
+//
+
+import Foundation
+import Combine
+
+class LoginSignupEventListener: ObservableObject {
+    @Published var dismiss: Bool = false
+}

--- a/Project_Timer/LoginSignup/LoginSignupVC.swift
+++ b/Project_Timer/LoginSignup/LoginSignupVC.swift
@@ -1,0 +1,31 @@
+//
+//  LoginSignupVC.swift
+//  Project_Timer
+//
+//  Created by Kang Minsang on 2023/09/25.
+//  Copyright © 2023 FDEE. All rights reserved.
+//
+
+import UIKit
+
+final class LoginSignupVC: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        self.view.backgroundColor = .systemBackground
+        // Do any additional setup after loading the view.
+        
+        let button = UIButton(configuration: .filled())
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.setTitle("close", for: .normal)
+        button.addAction(UIAction(handler: { [weak self] _ in
+            self?.dismiss(animated: true)
+        }), for: .touchUpInside)
+        
+        self.view.addSubview(button)
+        NSLayoutConstraint.activate([
+            button.centerXAnchor.constraint(equalTo: self.view.centerXAnchor),
+            button.centerYAnchor.constraint(equalTo: self.view.centerYAnchor)
+        ])
+    }
+}

--- a/Project_Timer/LoginSignup/LoginSignupVC.swift
+++ b/Project_Timer/LoginSignup/LoginSignupVC.swift
@@ -7,25 +7,44 @@
 //
 
 import UIKit
+import Combine
+import SwiftUI
 
 final class LoginSignupVC: UIViewController {
+    private let listener = LoginSignupEventListener()
+    private var cancellables: Set<AnyCancellable> = []
 
     override func viewDidLoad() {
         super.viewDidLoad()
         self.view.backgroundColor = .systemBackground
-        // Do any additional setup after loading the view.
         
-        let button = UIButton(configuration: .filled())
-        button.translatesAutoresizingMaskIntoConstraints = false
-        button.setTitle("close", for: .normal)
-        button.addAction(UIAction(handler: { [weak self] _ in
-            self?.dismiss(animated: true)
-        }), for: .touchUpInside)
+        self.configureHostingVC()
+        self.bindListener()
+    }
+    
+    private func configureHostingVC() {
+        let hostingVC = UIHostingController(rootView: LoginSelectView().environmentObject(listener))
+        self.addChild(hostingVC)
+        hostingVC.didMove(toParent: self)
         
-        self.view.addSubview(button)
+        hostingVC.view.translatesAutoresizingMaskIntoConstraints = false
+        self.view.addSubview(hostingVC.view)
         NSLayoutConstraint.activate([
-            button.centerXAnchor.constraint(equalTo: self.view.centerXAnchor),
-            button.centerYAnchor.constraint(equalTo: self.view.centerYAnchor)
+            hostingVC.view.topAnchor.constraint(equalTo: self.view.topAnchor),
+            hostingVC.view.leadingAnchor.constraint(equalTo: self.view.leadingAnchor),
+            hostingVC.view.trailingAnchor.constraint(equalTo: self.view.trailingAnchor),
+            hostingVC.view.bottomAnchor.constraint(equalTo: self.view.bottomAnchor)
         ])
+    }
+    
+    private func bindListener() {
+        self.listener.$dismiss
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] dismiss in
+                if dismiss {
+                    self?.dismiss(animated: true)
+                }
+            }
+            .store(in: &self.cancellables)
     }
 }

--- a/Project_Timer/Network/NetworkURL.swift
+++ b/Project_Timer/Network/NetworkURL.swift
@@ -14,8 +14,8 @@ enum NetworkURL {
     static let appstore: String = "itms-apps://itunes.apple.com/app/id1519159240"
     static let developmentList: String = "https://deeply-eggplant-5ec.notion.site/TiTi-Development-List-b089afc1a4eb4cdb8c06840ca9cb1273"
     static let instagramToTiTi: String = "https://www.instagram.com/study_withtiti/"
-    static let instagramToFDEE: String = "https://www.instagram.com/dev_fdee/"
-    static let github: String = "https://github.com/FreeDeveloper97"
+    static let instagramToDeveloper: String = "https://www.instagram.com/dev_mindsang/"
+    static let github: String = "https://github.com/TimerTiTi"
     
     enum Firestore {
         static let projectId: String = "titi-b8650"

--- a/Project_Timer/Setting/Main/SettingCellInfo.swift
+++ b/Project_Timer/Setting/Main/SettingCellInfo.swift
@@ -19,49 +19,30 @@ class SettingCellInfo {
     var switchable: Bool = false
     var toggleKey: UserDefaultsManager.Keys? = nil
     var action: SettingAction? = nil
-    var nextVCIdentifier: String? = nil
-    var url: String? = nil
-    var iconName: String = "none"
+    var destination: Destination? = nil
     
-    /// title  + pushVC
-    init(title: String, nextVCIdentifier: String) {
+    /// title (subTitle, rightTitle)
+    init(title: String, subTitle: String? = nil, rightTitle: String? = nil) {
         self.title = title
-        self.nextVCIdentifier = nextVCIdentifier
-        self.action = .pushVC
+        self.subTitle = subTitle
+        self.rightTitle = rightTitle
+        self.touchable = false
     }
-    /// title + subtitle + switch
-    init(title: String, subTitle: String, toggleKey: UserDefaultsManager.Keys) {
+    /// title (subTitle, rightTitle) + destination
+    init(title: String, subTitle: String? = nil, rightTitle: String? = nil, action: SettingAction, destination: Destination) {
+        self.title = title
+        self.subTitle = subTitle
+        self.rightTitle = rightTitle
+        self.action = action
+        self.destination = destination
+    }
+    /// title (subTitle) + switch
+    init(title: String, subTitle: String? = nil, toggleKey: UserDefaultsManager.Keys) {
         self.title = title
         self.subTitle = subTitle
         self.toggleKey = toggleKey
         self.switchable = true
         self.touchable = false
-    }
-    /// title + subtitle + righttitle + pushVC
-    init(title: String, subTitle: String, rightTitle: String, nextVCIdentifier: String) {
-        self.title = title
-        self.subTitle = subTitle
-        self.rightTitle = rightTitle
-        self.nextVCIdentifier = nextVCIdentifier
-        self.action = .pushVC
-    }
-    /// title + subtitle + righttitle + url
-    init(title: String, subTitle: String, rightTitle: String, link: String) {
-        self.title = title
-        self.subTitle = subTitle
-        self.rightTitle = rightTitle
-        self.url = link
-        self.action = .deeplink
-    }
-    /// title
-    init(title: String) {
-        self.title = title
-        self.touchable = false
-    }
-    /// without storyboard
-    init(title: String, vc: SettingAction) {
-        self.title = title
-        self.action = vc
     }
     
     func updateSubTitle(to subTitle: String) {
@@ -69,19 +50,34 @@ class SettingCellInfo {
     }
 }
 
+/// Cell 클릭 이벤트
 enum SettingAction: String {
     case pushVC
-    case goSafari
-    case deeplink
+    case modalFullscreen
+    case activityVC
+    case otherApp
+}
+
+/// push
+enum Destination {
+    case storyboardName(identifier: String)
+    case website(url: String)
+    case deeplink(url: String)
+    // class 분기처리
     case notification
     case ui
     case control
     case widget
+    case loginSelect
+    // other app 분기처리
+    case backup
+    case mail
 }
 
 protocol SettingActionDelegate: AnyObject {
-    func pushVC(nextVCIdentifier: String)
-    func goSafari(url: String)
-    func deeplink(link: String)
-    func showEmailPopup()
+    func pushVC(identifier: String)
+    func pushVC(destination: Destination)
+    func modalVC(fullscreen: Bool, destination: Destination)
+    func systemVC(destination: Destination)
+    func showOtherApp(destination: Destination)
 }

--- a/Project_Timer/Setting/Main/SettingDevInfoCell.swift
+++ b/Project_Timer/Setting/Main/SettingDevInfoCell.swift
@@ -25,15 +25,15 @@ final class SettingDevInfoCell: UICollectionViewCell {
     }
     
     @IBAction func showEmail(_ sender: Any) {
-        self.delegate?.showEmailPopup()
+        self.delegate?.systemVC(destination: .mail)
     }
     
     @IBAction func showInstagram(_ sender: Any) {
-        self.delegate?.goSafari(url: NetworkURL.instagramToFDEE)
+        self.delegate?.showOtherApp(destination: .website(url: NetworkURL.instagramToTiTi))
     }
     
     @IBAction func showGithub(_ sender: Any) {
-        self.delegate?.goSafari(url: NetworkURL.github)
+        self.delegate?.showOtherApp(destination: .website(url: NetworkURL.github))
     }
 }
 

--- a/Project_Timer/Setting/Main/SettingVM.swift
+++ b/Project_Timer/Setting/Main/SettingVM.swift
@@ -22,6 +22,7 @@ final class SettingVM {
     }
     
     private func configureSections() {
+        self.sections.append("Profile".localized())
         self.sections.append("Service".localized())
         self.sections.append("Setting".localized())
         self.sections.append("Version & Update history".localized())
@@ -30,20 +31,24 @@ final class SettingVM {
     }
     
     private func configureCells() {
-        let versionCell = SettingCellInfo(title: "Version Info".localized(), subTitle: "Latest version".localized()+":", rightTitle: String.currentVersion, link: NetworkURL.appstore)
+        let versionCell = SettingCellInfo(title: "Version Info".localized(), subTitle: "Latest version".localized()+":", rightTitle: String.currentVersion, action: .otherApp, destination: .deeplink(url: NetworkURL.appstore))
         
         var cells: [[SettingCellInfo]] = []
+        // Profile
+        cells.append([
+            SettingCellInfo(title: "Login".localized(), subTitle: "Try Synchronization".localized(), action: .modalFullscreen, destination: .loginSelect)
+        ])
         // Service
         cells.append([
-            SettingCellInfo(title: "TiTi Functions".localized(), nextVCIdentifier: SettingFunctionsListVC.identifier),
-            SettingCellInfo(title: "TiTi Lab".localized(), nextVCIdentifier: SettingTiTiLabVC.identifier)
+            SettingCellInfo(title: "TiTi Functions".localized(), action: .pushVC, destination: .storyboardName(identifier: SettingFunctionsListVC.identifier)),
+            SettingCellInfo(title: "TiTi Lab".localized(), action: .pushVC, destination: .storyboardName(identifier: SettingTiTiLabVC.identifier))
         ])
         // Setting
         cells.append([
-            SettingCellInfo(title: "Notification".localized(), vc: .notification),
-            SettingCellInfo(title: "UI", vc: .ui),
-            SettingCellInfo(title: "Control".localized(), vc: .control),
-            SettingCellInfo(title: "Widget".localized(), vc: .widget)
+            SettingCellInfo(title: "Notification".localized(), action: .pushVC, destination: .notification),
+            SettingCellInfo(title: "UI", action: .pushVC, destination: .ui),
+            SettingCellInfo(title: "Control".localized(), action: .pushVC, destination: .control),
+            SettingCellInfo(title: "Widget".localized(), action: .pushVC, destination: .widget)
         ])
         #if targetEnvironment(macCatalyst)
         cells.last?.remove(at: 2) // Control 제거
@@ -51,11 +56,11 @@ final class SettingVM {
         // Version & Update history
         cells.append([
             versionCell,
-            SettingCellInfo(title: "Update history".localized(), nextVCIdentifier: SettingUpdateHistoryVC.identifier)
+            SettingCellInfo(title: "Update history".localized(), action: .pushVC, destination: .storyboardName(identifier: SettingUpdateHistoryVC.identifier))
         ])
         // Backup
         cells.append([
-            SettingCellInfo(title: "Get Backup files".localized(), nextVCIdentifier: "showBackup")
+            SettingCellInfo(title: "Get Backup files".localized(), action: .activityVC, destination: .backup)
         ])
         // Developer
         cells.append([

--- a/Project_Timer/en.lproj/Localizable.strings
+++ b/Project_Timer/en.lproj/Localizable.strings
@@ -312,3 +312,7 @@
 "howToAddWidget_description_3" = "Search for \"TiTi\" and Tap.";
 "howToAddWidget_description_4" = "Select a Widget and size, then Tap \"Add Widget\".";
 "howToAddWidget_description_5" = "Now you can use Widget!";
+
+"Profile" = "Profile";
+"Login" = "Login";
+"Try Synchronization" = "Try Synchronization";

--- a/Project_Timer/ko.lproj/Localizable.strings
+++ b/Project_Timer/ko.lproj/Localizable.strings
@@ -316,3 +316,7 @@
 "howToAddWidget_description_3" = "\"TiTi\"를 검색한 후 터치해요";
 "howToAddWidget_description_4" = "위젯과 사이즈를 선택하고 \"위젯 추가\"를 터치해요";
 "howToAddWidget_description_5" = "그러면 위젯을 사용할 수 있어요!";
+
+"Profile" = "프로필";
+"Login" = "로그인하기";
+"Try Synchronization" = "동기화 기능을 사용해보세요";


### PR DESCRIPTION
### 개요
- Issue:  #93 
- Tech Spec: [회원 관리 기능 개발](https://www.notion.so/timertiti/4cb5c74f656e4bf784cff130213fd086?pvs=4)
- Figma: [로그인 프로세스](https://www.figma.com/file/T8hsaAguFkPytBiNMOOw03/Develop?type=design&node-id=670-9559&mode=design)

---

### 변경사항
- [x] SettingCellInfo init 함수 수정
- [x] SettingAction 및 Destination 수정 및 생성
- [x] SettingActionDelegate 수정
- [x] LoginSignupVC 생성
- [x] HostingVC 기반 LoginSelectView 표시 구현

<img src="https://github.com/TimerTiTi/TiTi_iOS/assets/65349445/af208a7f-d226-411e-a57f-869780403ada" height=500>

### Fact
- UIKit 기반에서 Storyboard name 기반, 코드기반, 또는 SwiftUI 화면전환 구현
- SwiftUI -> UIKit 이벤트전달 및 수신 구현

### Lesson
- Storyboard 기반, 코드기반, SwiftUI뷰 등 다양한 형식의 화면으로 전환되기 위한 enum 구조 고민
- UIHostingVC를 사용하여 SwiftUI를 표시하는 것을 넘어서 SwiftUI 에서 이벤트를 받기 위한 Listener 구조 고민
- environment를 통해 하위 SwiftUI까지 ObservableObject를 전달할 수 있다는 것을 알게됨
