### PR TITLE
배포환경설정 및 Develop, Release용 Scheme, Configuration 분리

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,5 +56,4 @@ Secrets
 Secrets.tar
 # link : https://github.com/firebase/quickstart-ios/blob/master/.gitignore
 
-AdMob.xcconfig
-env.xcconfig
+*.xcconfig

--- a/Podfile
+++ b/Podfile
@@ -1,5 +1,10 @@
 # Uncomment the next line to define a global platform for your project
-platform :ios, '9.0'
+platform :ios, '12.0'
+
+project 'Project_Timer',
+  'Debug' => :debug,
+  'Develop' => :debug,
+  'Release' => :release
 
 target 'Project_Timer' do
   # Comment the next line if you don't want to use dynamic frameworks

--- a/Project_Timer.xcodeproj/project.pbxproj
+++ b/Project_Timer.xcodeproj/project.pbxproj
@@ -354,7 +354,7 @@
 		8721C6D8296941F800410D57 /* UIScrollView+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIScrollView+Extension.swift"; sourceTree = "<group>"; };
 		8721C6DA296943C500410D57 /* ChangeNextGraphButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangeNextGraphButton.swift; sourceTree = "<group>"; };
 		8721C6DC296944EE00410D57 /* ChangePrevGraphButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangePrevGraphButton.swift; sourceTree = "<group>"; };
-		872B7552296A625B00D24394 /* env.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = env.xcconfig; sourceTree = "<group>"; };
+		872B7552296A625B00D24394 /* production.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = production.xcconfig; sourceTree = "<group>"; };
 		872C0EDA284ADD8300E8E3F2 /* SettingUpdateHistoryVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingUpdateHistoryVC.swift; sourceTree = "<group>"; };
 		872C0EDD284AE52800E8E3F2 /* SettingFunctionsListVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingFunctionsListVC.swift; sourceTree = "<group>"; };
 		872C0EE0284AE57200E8E3F2 /* SettingTiTiLabVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingTiTiLabVC.swift; sourceTree = "<group>"; };
@@ -416,6 +416,7 @@
 		8765234E28C7964500487BFB /* TotalVM.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TotalVM.swift; sourceTree = "<group>"; };
 		8765235028C79C4400487BFB /* TotalView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TotalView.swift; sourceTree = "<group>"; };
 		8769349627E1BBAF00D33F51 /* TodoCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodoCell.swift; sourceTree = "<group>"; };
+		876E27712AC1C9D30054250D /* development.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = development.xcconfig; sourceTree = "<group>"; };
 		877036C929CD7B3B0078A30C /* TaskManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskManager.swift; sourceTree = "<group>"; };
 		8771190C28954B4A00F53FAD /* StandardWeekTaskCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = StandardWeekTaskCell.xib; sourceTree = "<group>"; };
 		8772E91526705EE100A191BF /* TodolistVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodolistVC.swift; sourceTree = "<group>"; };
@@ -552,6 +553,7 @@
 		93B08534248DEEBA00E215BD /* Project_Timer.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Project_Timer.entitlements; sourceTree = "<group>"; };
 		A9F348000F0D4026C9EBB793 /* Pods-Project_Timer.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Project_Timer.debug.xcconfig"; path = "Target Support Files/Pods-Project_Timer/Pods-Project_Timer.debug.xcconfig"; sourceTree = "<group>"; };
 		EF0BDFDFBC511E7A47A45D16 /* Pods-Project_Timer.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Project_Timer.release.xcconfig"; path = "Target Support Files/Pods-Project_Timer/Pods-Project_Timer.release.xcconfig"; sourceTree = "<group>"; };
+		F426A4BDC73F07A7F14D3249 /* Pods-Project_Timer.develop.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Project_Timer.develop.xcconfig"; path = "Target Support Files/Pods-Project_Timer/Pods-Project_Timer.develop.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1384,7 +1386,8 @@
 				93B08522248DDF2F00E215BD /* SceneDelegate.swift */,
 				878D3C1E266494380093A2BE /* GoogleService-Info.plist */,
 				93B0852E248DDF3000E215BD /* Info.plist */,
-				872B7552296A625B00D24394 /* env.xcconfig */,
+				876E27712AC1C9D30054250D /* development.xcconfig */,
+				872B7552296A625B00D24394 /* production.xcconfig */,
 			);
 			path = Project_Timer;
 			sourceTree = "<group>";
@@ -1394,6 +1397,7 @@
 			children = (
 				A9F348000F0D4026C9EBB793 /* Pods-Project_Timer.debug.xcconfig */,
 				EF0BDFDFBC511E7A47A45D16 /* Pods-Project_Timer.release.xcconfig */,
+				F426A4BDC73F07A7F14D3249 /* Pods-Project_Timer.develop.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -1883,6 +1887,126 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
+		876E27722AC1CA100054250D /* Develop */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.5;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Develop;
+		};
+		876E27732AC1CA100054250D /* Develop */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 876E27712AC1C9D30054250D /* development.xcconfig */;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = Project_Timer/Project_Timer.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 2C96RNDN63;
+				"ENABLE_HARDENED_RUNTIME[sdk=macosx*]" = YES;
+				INFOPLIST_FILE = Project_Timer/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 7.15.1;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(APP_BUNDLE_ID)";
+				PRODUCT_NAME = "$(APP_NAME)";
+				SUPPORTS_MACCATALYST = YES;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Develop;
+		};
+		876E27742AC1CA100054250D /* Develop */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CODE_SIGN_ENTITLEMENTS = widgetExtension.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 2C96RNDN63;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = widget/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = widget;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2023 FDEE. All rights reserved.";
+				IPHONEOS_DEPLOYMENT_TARGET = 16.2;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.FDEE.TiTi.dev.widget;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SUPPORTS_MACCATALYST = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Develop;
+		};
 		878B30FA2992BB5B00BE7413 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -2065,7 +2189,7 @@
 		};
 		93B08532248DDF3000E215BD /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 872B7552296A625B00D24394 /* env.xcconfig */;
+			baseConfigurationReference = 872B7552296A625B00D24394 /* production.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
@@ -2081,8 +2205,8 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 7.15.1;
-				PRODUCT_BUNDLE_IDENTIFIER = com.FDEE.TiTi;
-				PRODUCT_NAME = TiTi;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(APP_BUNDLE_ID)";
+				PRODUCT_NAME = "$(APP_NAME)";
 				SUPPORTS_MACCATALYST = YES;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_VERSION = 5.0;
@@ -2092,7 +2216,7 @@
 		};
 		93B08533248DDF3000E215BD /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 872B7552296A625B00D24394 /* env.xcconfig */;
+			baseConfigurationReference = 872B7552296A625B00D24394 /* production.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
@@ -2108,8 +2232,8 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 7.15.1;
-				PRODUCT_BUNDLE_IDENTIFIER = com.FDEE.TiTi;
-				PRODUCT_NAME = TiTi;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(APP_BUNDLE_ID)";
+				PRODUCT_NAME = "$(APP_NAME)";
 				SUPPORTS_MACCATALYST = YES;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_VERSION = 5.0;
@@ -2124,6 +2248,7 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				878B30FA2992BB5B00BE7413 /* Debug */,
+				876E27742AC1CA100054250D /* Develop */,
 				878B30FB2992BB5B00BE7413 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
@@ -2133,6 +2258,7 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				93B0852F248DDF3000E215BD /* Debug */,
+				876E27722AC1CA100054250D /* Develop */,
 				93B08530248DDF3000E215BD /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
@@ -2142,6 +2268,7 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				93B08532248DDF3000E215BD /* Debug */,
+				876E27732AC1CA100054250D /* Develop */,
 				93B08533248DDF3000E215BD /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;

--- a/Project_Timer.xcodeproj/project.pbxproj
+++ b/Project_Timer.xcodeproj/project.pbxproj
@@ -134,6 +134,7 @@
 		8765234F28C7964500487BFB /* TotalVM.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8765234E28C7964500487BFB /* TotalVM.swift */; };
 		8765235128C79C4400487BFB /* TotalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8765235028C79C4400487BFB /* TotalView.swift */; };
 		8769349727E1BBAF00D33F51 /* TodoCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8769349627E1BBAF00D33F51 /* TodoCell.swift */; };
+		876E27762AC1CD2A0054250D /* Infos.swift in Sources */ = {isa = PBXBuildFile; fileRef = 876E27752AC1CD2A0054250D /* Infos.swift */; };
 		877036CA29CD7B3B0078A30C /* TaskManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 877036C929CD7B3B0078A30C /* TaskManager.swift */; };
 		8771190D28954B4A00F53FAD /* StandardWeekTaskCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 8771190C28954B4A00F53FAD /* StandardWeekTaskCell.xib */; };
 		8772E91626705EE100A191BF /* TodolistVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8772E91526705EE100A191BF /* TodolistVC.swift */; };
@@ -417,6 +418,7 @@
 		8765235028C79C4400487BFB /* TotalView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TotalView.swift; sourceTree = "<group>"; };
 		8769349627E1BBAF00D33F51 /* TodoCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodoCell.swift; sourceTree = "<group>"; };
 		876E27712AC1C9D30054250D /* development.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = development.xcconfig; sourceTree = "<group>"; };
+		876E27752AC1CD2A0054250D /* Infos.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Infos.swift; sourceTree = "<group>"; };
 		877036C929CD7B3B0078A30C /* TaskManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskManager.swift; sourceTree = "<group>"; };
 		8771190C28954B4A00F53FAD /* StandardWeekTaskCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = StandardWeekTaskCell.xib; sourceTree = "<group>"; };
 		8772E91526705EE100A191BF /* TodolistVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodolistVC.swift; sourceTree = "<group>"; };
@@ -1069,6 +1071,7 @@
 				87035DF6282225C800055378 /* Protocols.swift */,
 				87D1250028771AAD00018658 /* Language.swift */,
 				87B539AA299BB710001E354C /* Versions.swift */,
+				876E27752AC1CD2A0054250D /* Infos.swift */,
 				87FD9FA92998D58900D9B0FF /* SingletonClass */,
 				87A48BC527DEF0B200F46D0F /* Extension */,
 				87BF666828F809DE00CD6F19 /* TimeLabelView */,
@@ -1766,6 +1769,7 @@
 				8788997F2894F03300B7F378 /* StandardWeekGraphView.swift in Sources */,
 				8721C6D9296941F800410D57 /* UIScrollView+Extension.swift in Sources */,
 				8788AFE528828D3500D26E7D /* LogDailyVC.swift in Sources */,
+				876E27762AC1CD2A0054250D /* Infos.swift in Sources */,
 				87D7ED1D2952E3F600121DE6 /* SignupLoginVC.swift in Sources */,
 				049BBA9C28AB58D4005BAB1B /* InteractionLeftTitleLabel.swift in Sources */,
 				871AB69D2967C9D100AFED1C /* TimeTableVM.swift in Sources */,

--- a/Project_Timer.xcodeproj/xcshareddata/xcschemes/Project_Timer (dev).xcscheme
+++ b/Project_Timer.xcodeproj/xcshareddata/xcschemes/Project_Timer (dev).xcscheme
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1500"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "93B0851C248DDF2F00E215BD"
+               BuildableName = "TiTi.app"
+               BlueprintName = "Project_Timer"
+               ReferencedContainer = "container:Project_Timer.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Develop"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Develop"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "93B0851C248DDF2F00E215BD"
+            BuildableName = "TiTi.app"
+            BlueprintName = "Project_Timer"
+            ReferencedContainer = "container:Project_Timer.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Develop"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "93B0851C248DDF2F00E215BD"
+            BuildableName = "TiTi.app"
+            BlueprintName = "Project_Timer"
+            ReferencedContainer = "container:Project_Timer.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Develop">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Develop"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Project_Timer.xcodeproj/xcshareddata/xcschemes/widgetExtension.xcscheme
+++ b/Project_Timer.xcodeproj/xcshareddata/xcschemes/widgetExtension.xcscheme
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1500"
+   wasCreatedForAppExtension = "YES"
+   version = "2.0">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "878B30E22992BB5A00BE7413"
+               BuildableName = "widgetExtension.appex"
+               BlueprintName = "widgetExtension"
+               ReferencedContainer = "container:Project_Timer.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "93B0851C248DDF2F00E215BD"
+               BuildableName = "TiTi.app"
+               BlueprintName = "Project_Timer"
+               ReferencedContainer = "container:Project_Timer.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = ""
+      selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
+      launchStyle = "0"
+      askForAppToLaunch = "Yes"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES"
+      launchAutomaticallySubstyle = "2">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "93B0851C248DDF2F00E215BD"
+            BuildableName = "TiTi.app"
+            BlueprintName = "Project_Timer"
+            ReferencedContainer = "container:Project_Timer.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "_XCWidgetKind"
+            value = ""
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "_XCWidgetDefaultView"
+            value = "timeline"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "_XCWidgetFamily"
+            value = "systemMedium"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES"
+      askForAppToLaunch = "Yes"
+      launchAutomaticallySubstyle = "2">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "93B0851C248DDF2F00E215BD"
+            BuildableName = "TiTi.app"
+            BlueprintName = "Project_Timer"
+            ReferencedContainer = "container:Project_Timer.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Project_Timer/Global/Infos.swift
+++ b/Project_Timer/Global/Infos.swift
@@ -1,0 +1,22 @@
+//
+//  Infos.swift
+//  Project_Timer
+//
+//  Created by Kang Minsang on 2023/09/25.
+//  Copyright © 2023 FDEE. All rights reserved.
+//
+
+import Foundation
+
+enum Infos: String {
+    case MODE
+    case ServerURL
+    
+    var value: String {
+        return Bundle.main.infoDictionary?[self.rawValue] as? String ?? ""
+    }
+    
+    static var isDevMode: Bool {
+        return Infos.MODE.value == "dev"
+    }
+}

--- a/Project_Timer/Info.plist
+++ b/Project_Timer/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>MODE</key>
+	<string>$(MODE)</string>
 	<key>ADMOB_AD_ID</key>
 	<string>$(ADMOB_AD_ID)</string>
 	<key>CFBundleDevelopmentRegion</key>
@@ -209,8 +211,8 @@
 			<string>3qcr597p9d.skadnetwork</string>
 		</dict>
 	</array>
-	<key>TestServerURL</key>
-	<string>$(TestServerURL)</string>
+	<key>ServerURL</key>
+	<string>$(ServerURL)</string>
 	<key>UIAppFonts</key>
 	<array>
 		<string>HGGGOTHICSSI_PRO_00G.otf</string>

--- a/Project_Timer/Setting/Main/SettingVM.swift
+++ b/Project_Timer/Setting/Main/SettingVM.swift
@@ -22,7 +22,11 @@ final class SettingVM {
     }
     
     private func configureSections() {
-        self.sections.append("Profile".localized())
+        // MARK: Dev
+        if Infos.isDevMode {
+            self.sections.append("Profile".localized())
+        }
+        
         self.sections.append("Service".localized())
         self.sections.append("Setting".localized())
         self.sections.append("Version & Update history".localized())
@@ -34,10 +38,14 @@ final class SettingVM {
         let versionCell = SettingCellInfo(title: "Version Info".localized(), subTitle: "Latest version".localized()+":", rightTitle: String.currentVersion, action: .otherApp, destination: .deeplink(url: NetworkURL.appstore))
         
         var cells: [[SettingCellInfo]] = []
-        // Profile
-        cells.append([
-            SettingCellInfo(title: "Login".localized(), subTitle: "Try Synchronization".localized(), action: .modalFullscreen, destination: .loginSelect)
-        ])
+        // MARK: Dev
+        if Infos.isDevMode {
+            // Profile
+            cells.append([
+                SettingCellInfo(title: "Login".localized(), subTitle: "Try Synchronization".localized(), action: .modalFullscreen, destination: .loginSelect)
+            ])
+        }
+        
         // Service
         cells.append([
             SettingCellInfo(title: "TiTi Functions".localized(), action: .pushVC, destination: .storyboardName(identifier: SettingFunctionsListVC.identifier)),


### PR DESCRIPTION
### 개요
- Github Flow를 통해 기능이 개발될 때 마다 main에 merge 하는 식으로 개발될 예정.
- 하지만 로그인 프로세스를 개발하기까지 매우 많은 시간이 걸리고, 자주 main 브렌치에 반영될 것이다.
- 만약 개발중에 버그가 발견되어 빠른 대응이 필요한 경우가 문제가 될 수 있다.
- 따라서 프로젝트 내 Scheme 분리를 통해 같은 프로젝트 코드여도 환경변수 값에 따라 개발중인 기능이 표시되지 않도록 한다.
- Scheme 변경만으로 환경변수가 변경되어 손쉽게 배포용 앱 상태와 개발진행중인 앱 상태를 오가며 개발할 수 있도록 개선하였다.

---

### 변경사항
- [x] Podfile 변경
- [x] development.xcconfig, production.xcconfig 환경변수 분리
- [x] Develop configuration 추가
- [x] Timer_Project (dev) Scheme 추가
- [x] Bundle identifier, Bundle Name 을 분리하여 각기 다른 앱으로 동작될 수 있도록 분리
- [x] Infos enum 추가 (Bundle.main.infoDictionary 값들을 관리하는 enum)
- [x] isDevMode 값에 따른 분기처리 추가

<img src="https://github.com/TimerTiTi/TiTi_iOS/assets/65349445/69205f22-7928-47ae-b4f5-12e6d4da5e67">

### Fact
- Scheme 분리 및 환경변수 분리 작업
- Scheme에 따라 환경변수값에 따라 Bundle Identifier 및 Bundle Name을 달리 설정하여 다른 앱으로 설치될 수 있도록 개선
- Widget Bundle Identifier의 경우 bundle identifier 변화에 따라 widget bundle identifier 또한 달리 설정되도록 분리

### Lesson
- 환경변수 분리를 통해 같은 변수를 다른 값으로 사용할 수 있는 특성으로 내부적인 분기처리 없이 프로젝트 개발이 가능하다는 것을 알게됨
- 환경변수 분리를 통해 bundle identifier를 분리할 수 있어 배포용, 개발용 앱을 분리할 수 있다는 것을 알게됨
- GithubFlow를 사용하면서도 빠르게 대응할 수 있는 구조에 대해 고민함

### Reference
- [[iOS - swift] Xcode 배포환경 설정](https://ios-development.tistory.com/660)
- [How to Set Up Xcode Build Configurations](https://orjpap.github.io/xcode/ios/swift/cocoapods/2020/04/20/iOS-build-schemes.html)
- [🐛 : Unable to install pods using custom build configurations](https://github.com/CocoaPods/CocoaPods/issues/10015)
