### PR TITLE
Network Error 핸들링 개선 & Alert Message 문구 관리

### DIFF
--- a/Project_Timer.xcodeproj/project.pbxproj
+++ b/Project_Timer.xcodeproj/project.pbxproj
@@ -49,6 +49,8 @@
 		870E11762A0E226D00CFA77C /* CalendarWidgetData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 870E11742A0E226D00CFA77C /* CalendarWidgetData.swift */; };
 		870E117B2A0F7DEE00CFA77C /* CalendarWidgetCellData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 870E117A2A0F7DEE00CFA77C /* CalendarWidgetCellData.swift */; };
 		870E117C2A0F7EF000CFA77C /* CalendarWidgetCellData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 870E117A2A0F7DEE00CFA77C /* CalendarWidgetCellData.swift */; };
+		87163DC82ACAF2E8008D4072 /* NetworkError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87163DC72ACAF2E8008D4072 /* NetworkError.swift */; };
+		87163DCA2ACAF89B008D4072 /* NetworkResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87163DC92ACAF89B008D4072 /* NetworkResult.swift */; };
 		87168D99299A819F003ED502 /* UserDefaults+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 875C98C82871BFCF008F7ADD /* UserDefaults+Extension.swift */; };
 		87199F442882BC430017D01A /* StandardDailyGraphView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87199F432882BC430017D01A /* StandardDailyGraphView.swift */; };
 		87199F462883018C0017D01A /* TimelineDailyGraphView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87199F452883018C0017D01A /* TimelineDailyGraphView.swift */; };
@@ -345,6 +347,8 @@
 		870474F528F148C700CC03A8 /* SettingColorVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingColorVC.swift; sourceTree = "<group>"; };
 		870E11742A0E226D00CFA77C /* CalendarWidgetData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarWidgetData.swift; sourceTree = "<group>"; };
 		870E117A2A0F7DEE00CFA77C /* CalendarWidgetCellData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarWidgetCellData.swift; sourceTree = "<group>"; };
+		87163DC72ACAF2E8008D4072 /* NetworkError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkError.swift; sourceTree = "<group>"; };
+		87163DC92ACAF89B008D4072 /* NetworkResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkResult.swift; sourceTree = "<group>"; };
 		87199F432882BC430017D01A /* StandardDailyGraphView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StandardDailyGraphView.swift; sourceTree = "<group>"; };
 		87199F452883018C0017D01A /* TimelineDailyGraphView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineDailyGraphView.swift; sourceTree = "<group>"; };
 		87199F47288303B60017D01A /* TasksProgressDailyGraphView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TasksProgressDailyGraphView.swift; sourceTree = "<group>"; };
@@ -1025,9 +1029,11 @@
 				8791081E28387537005D7B10 /* NetworkURL.swift */,
 				87910820283875C0005D7B10 /* NetworkController.swift */,
 				87910822283875CF005D7B10 /* NetworkProtocols.swift */,
-				879108242838761B005D7B10 /* NetworkStatus.swift */,
 				875EDA332957E0360037A7EB /* NetworkInterceptor.swift */,
 				87910829283877A4005D7B10 /* Network.swift */,
+				879108242838761B005D7B10 /* NetworkStatus.swift */,
+				87163DC92ACAF89B008D4072 /* NetworkResult.swift */,
+				87163DC72ACAF2E8008D4072 /* NetworkError.swift */,
 				87D7ED182952BA7200121DE6 /* Extension */,
 				8791082B28387B9B005D7B10 /* DTO */,
 			);
@@ -1662,6 +1668,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				877911B22A188A3200F0A713 /* SettingSwitchListVC.swift in Sources */,
+				87163DC82ACAF2E8008D4072 /* NetworkError.swift in Sources */,
 				87D5E65028C7460100D53F8D /* MonthSmallVM.swift in Sources */,
 				879D20742A190DE900D8A420 /* LogSettingVC.swift in Sources */,
 				8721C6DD296944EE00410D57 /* ChangePrevGraphButton.swift in Sources */,
@@ -1681,6 +1688,7 @@
 				878BF7ED2955E5430044C079 /* SyncDailysVM.swift in Sources */,
 				879BE3242AC42758007AAC46 /* TiTiImage.swift in Sources */,
 				873C197A28D04B5B00E02ADC /* DayOfWeekText.swift in Sources */,
+				87163DCA2ACAF89B008D4072 /* NetworkResult.swift in Sources */,
 				874F9C2B2ABFF51700675A86 /* LoginSelectView.swift in Sources */,
 				871C1A0328519CC200BDAE02 /* SettingDevInfoCell.swift in Sources */,
 				87ED9ABF28D16FC200186677 /* TasksCircularProgressDTO.swift in Sources */,

--- a/Project_Timer.xcodeproj/project.pbxproj
+++ b/Project_Timer.xcodeproj/project.pbxproj
@@ -1027,8 +1027,8 @@
 			isa = PBXGroup;
 			children = (
 				8791081E28387537005D7B10 /* NetworkURL.swift */,
-				87910820283875C0005D7B10 /* NetworkController.swift */,
 				87910822283875CF005D7B10 /* NetworkProtocols.swift */,
+				87910820283875C0005D7B10 /* NetworkController.swift */,
 				875EDA332957E0360037A7EB /* NetworkInterceptor.swift */,
 				87910829283877A4005D7B10 /* Network.swift */,
 				879108242838761B005D7B10 /* NetworkStatus.swift */,

--- a/Project_Timer.xcodeproj/project.pbxproj
+++ b/Project_Timer.xcodeproj/project.pbxproj
@@ -2032,7 +2032,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = Project_Timer/Project_Timer.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 3;
 				DEVELOPMENT_TEAM = 2C96RNDN63;
 				"ENABLE_HARDENED_RUNTIME[sdk=macosx*]" = YES;
 				INFOPLIST_FILE = Project_Timer/Info.plist;
@@ -2271,7 +2271,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = Project_Timer/Project_Timer.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 3;
 				DEVELOPMENT_TEAM = 2C96RNDN63;
 				"ENABLE_HARDENED_RUNTIME[sdk=macosx*]" = YES;
 				INFOPLIST_FILE = Project_Timer/Info.plist;
@@ -2298,7 +2298,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = Project_Timer/Project_Timer.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 3;
 				DEVELOPMENT_TEAM = 2C96RNDN63;
 				"ENABLE_HARDENED_RUNTIME[sdk=macosx*]" = YES;
 				INFOPLIST_FILE = Project_Timer/Info.plist;

--- a/Project_Timer.xcodeproj/project.pbxproj
+++ b/Project_Timer.xcodeproj/project.pbxproj
@@ -2032,7 +2032,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = Project_Timer/Project_Timer.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_TEAM = 2C96RNDN63;
 				"ENABLE_HARDENED_RUNTIME[sdk=macosx*]" = YES;
 				INFOPLIST_FILE = Project_Timer/Info.plist;
@@ -2271,7 +2271,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = Project_Timer/Project_Timer.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_TEAM = 2C96RNDN63;
 				"ENABLE_HARDENED_RUNTIME[sdk=macosx*]" = YES;
 				INFOPLIST_FILE = Project_Timer/Info.plist;
@@ -2298,7 +2298,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = Project_Timer/Project_Timer.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_TEAM = 2C96RNDN63;
 				"ENABLE_HARDENED_RUNTIME[sdk=macosx*]" = YES;
 				INFOPLIST_FILE = Project_Timer/Info.plist;

--- a/Project_Timer/AppDelegate.swift
+++ b/Project_Timer/AppDelegate.swift
@@ -71,11 +71,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     /// 최신버전 체크로직
     private func checkVersion() {
         guard UserDefaultsManager.get(forKey: .updatePushable) as? Bool ?? true else { return }
-        NetworkController(network: Network()).getAppstoreVersion { status, version in
-            switch status {
-            case .SUCCESS:
-                guard let storeVersion = version else { return }
-                
+        NetworkController(network: Network()).getAppstoreVersion { result in
+            switch result {
+            case .success(let storeVersion):
                 if storeVersion.compare(String.currentVersion, options: .numeric) == .orderedDescending {
                     let message = "Please download the ".localized() + storeVersion + " version of the App Store :)".localized()
                     let alert = UIAlertController(title: "Update new version".localized(), message: message, preferredStyle: .alert)
@@ -91,8 +89,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                     alert.addAction(update)
                     SceneDelegate.sharedWindow?.rootViewController?.present(alert, animated: true)
                 }
-            default:
-                return
+            case .failure(let error):
+                print(error.alertMessage)
             }
         }
     }

--- a/Project_Timer/Network/Network.swift
+++ b/Project_Timer/Network/Network.swift
@@ -42,7 +42,7 @@ extension Network {
     private func configureNetworkResult(response: AFDataResponse<Data?>) -> NetworkResult {
         guard let statusCode = response.response?.statusCode else {
             print("[Network] Fail: No Status Code, \(String(describing: response.error))")
-            return NetworkResult(status: response.error?.isRequestRetryError == true ? .TIMEOUT : .CLIENTERROR, data: nil)
+            return NetworkResult(status: response.error?.isRequestRetryError == true ? .TIMEOUT : .FAIL, data: nil)
         }
         
         let status = NetworkStatus.status(statusCode)

--- a/Project_Timer/Network/Network.swift
+++ b/Project_Timer/Network/Network.swift
@@ -52,6 +52,12 @@ extension Network {
             return NetworkResult(status: status, data: nil)
         }
         
+        // server로부터 받은 data가 'null' 값인 경우 추가처리
+        if String(data: data, encoding: .utf8) == "null" {
+            print("[Network] Warning(\(statusCode)): null")
+            return NetworkResult(status: status, data: nil)
+        }
+        
         if Infos.isDevMode {
             print("[Network] url: \(String(describing: response.request?.url))")
             print("[Network] statusCode: \(statusCode)")

--- a/Project_Timer/Network/NetworkController.swift
+++ b/Project_Timer/Network/NetworkController.swift
@@ -26,23 +26,22 @@ final class NetworkController {
 }
 
 extension NetworkController: VersionFetchable {
-    func getAppstoreVersion(completion: @escaping (NetworkStatus, String?) -> Void) {
+    func getAppstoreVersion(completion: @escaping (Result<String, NetworkError>) -> Void) {
         self.network.request(url: NetworkURL.Firestore.lastestVersion, method: .get) { result in
             switch result.status {
             case .SUCCESS:
                 guard let data = result.data,
                       let lastestVersionInfo: LastestVersionInfo = try? JSONDecoder().decode(LastestVersionInfo.self, from: data) else {
-                    print("Decode Error: LastestVersionInfo")
-                    completion(.DECODEERROR, nil)
+                    completion(.failure(.DECODEERROR))
                     return
                 }
                 #if targetEnvironment(macCatalyst)
-                completion(.SUCCESS, lastestVersionInfo.macOS.value)
+                completion(.success(lastestVersionInfo.macOS.value))
                 #else
-                completion(.SUCCESS, lastestVersionInfo.iOS.value)
+                completion(.success(lastestVersionInfo.iOS.value))
                 #endif
             default:
-                completion(result.status, nil)
+                completion(.failure(NetworkError.error(result)))
                 return
             }
         }

--- a/Project_Timer/Network/NetworkController.swift
+++ b/Project_Timer/Network/NetworkController.swift
@@ -182,16 +182,19 @@ extension NetworkController: TestServerDailyFetchable {
 
 
 extension NetworkController: TestServerSyncLogFetchable {
-    func getSyncLog(completion: @escaping (Result<SyncLog, NetworkError>) -> Void) {
+    func getSyncLog(completion: @escaping (Result<SyncLog?, NetworkError>) -> Void) {
         self.network.request(url: NetworkURL.TestServer.syncLog, method: .get) { result in
             switch result.status {
             case .SUCCESS:
-                guard let data = result.data,
-                      let syncLog = try? JSONDecoder.dateFormatted.decode(SyncLog.self, from: data) else {
-                    completion(.failure(.DECODEERROR))
-                    return
+                if let data = result.data {
+                    guard let syncLog = try? JSONDecoder.dateFormatted.decode(SyncLog.self, from: data) else {
+                        completion(.failure(.DECODEERROR))
+                        return
+                    }
+                    completion(.success(syncLog))
+                } else {
+                    completion(.success(nil))
                 }
-                completion(.success(syncLog))
             default:
                 completion(.failure(NetworkError.error(result)))
             }

--- a/Project_Timer/Network/NetworkController.swift
+++ b/Project_Timer/Network/NetworkController.swift
@@ -162,12 +162,12 @@ extension NetworkController: TestServerAuthFetchable {
                     return
                 }
                 completion(.SUCCESS, token)
-            case.FAIL:
+            case.CLIENTERROR:
                 if KeyChain.shared.deleteAll() {
                     UserDefaultsManager.set(to: false, forKey: .loginInTestServerV1)
                     NotificationCenter.default.post(name: KeyChain.logouted, object: nil)
                 }
-                completion(.FAIL, nil)
+                completion(.CLIENTERROR, nil)
             default:
                 completion(result.status, nil)
                 return

--- a/Project_Timer/Network/NetworkError.swift
+++ b/Project_Timer/Network/NetworkError.swift
@@ -84,7 +84,7 @@ enum NetworkError: Error {
         case .NOTFOUND(_):
             return "Please update to the latest version".localized()
         case .CONFLICT(_):
-            return "Please enter other information".localized()
+            return "Please enter your nickname or email in a different value".localized()
         case .SERVERERROR(_):
             return "The server encountered an error. Please try again in a few minutes".localized()
         default:

--- a/Project_Timer/Network/NetworkError.swift
+++ b/Project_Timer/Network/NetworkError.swift
@@ -91,4 +91,9 @@ enum NetworkError: Error {
             return "Please check the network and try again".localized()
         }
     }
+    
+    /// 범용적으로 표시되는 alert문구의 조합을 반환
+    var alertMessage: (title: String, text: String) {
+        return (title: self.title, text: self.message)
+    }
 }

--- a/Project_Timer/Network/NetworkError.swift
+++ b/Project_Timer/Network/NetworkError.swift
@@ -78,15 +78,15 @@ enum NetworkError: Error {
         case .TIMEOUT:
             return "Please check the network and try again".localized()
         case .DECODEERROR:
-            return "Please update to the latest version".localized()
+            return "Please update to the latest version of the app".localized()
         case .AUTHENTICATION(_):
             return "Please log in again".localized()
         case .NOTFOUND(_):
-            return "Please update to the latest version".localized()
+            return "Please update to the latest version of the app".localized()
         case .CONFLICT(_):
             return "Please enter your nickname or email in a different value".localized()
         case .SERVERERROR(_):
-            return "The server encountered an error. Please try again in a few minutes".localized()
+            return "The server something went wrong. Please try again in a few minutes".localized()
         default:
             return "Please check the network and try again".localized()
         }

--- a/Project_Timer/Network/NetworkError.swift
+++ b/Project_Timer/Network/NetworkError.swift
@@ -47,4 +47,48 @@ enum NetworkError: Error {
             return .FAIL
         }
     }
+    
+    /// 범용적으로 표시될 수 있는 alert title 값, CLIENTERROR의 경우 VM에서 처리
+    var title: String {
+        switch self {
+        case .FAIL:
+            return "Network Error".localized()
+        case .TIMEOUT:
+            return "Network Timeout".localized()
+        case .DECODEERROR:
+            return "Network Fetch Error".localized()
+        case .AUTHENTICATION(_):
+            return "Authentication Error".localized()
+        case .NOTFOUND(_):
+            return "Network Fetch Error".localized()
+        case .CONFLICT(_):
+            return "Signup Error".localized()
+        case .SERVERERROR(_):
+            return "Server Error".localized()
+        default:
+            return "Network Error".localized()
+        }
+    }
+    
+    /// 범용적으로 표시될 수 있는 alert message 값, CLIENTERROR의 경우 VM에서 처리
+    var message: String {
+        switch self {
+        case .FAIL:
+            return "Please check the network and try again".localized()
+        case .TIMEOUT:
+            return "Please check the network and try again".localized()
+        case .DECODEERROR:
+            return "Please update to the latest version".localized()
+        case .AUTHENTICATION(_):
+            return "Please log in again".localized()
+        case .NOTFOUND(_):
+            return "Please update to the latest version".localized()
+        case .CONFLICT(_):
+            return "Please enter other information".localized()
+        case .SERVERERROR(_):
+            return "The server encountered an error. Please try again in a few minutes".localized()
+        default:
+            return "Please check the network and try again".localized()
+        }
+    }
 }

--- a/Project_Timer/Network/NetworkError.swift
+++ b/Project_Timer/Network/NetworkError.swift
@@ -1,0 +1,50 @@
+//
+//  NetworkError.swift
+//  Project_Timer
+//
+//  Created by Kang Minsang on 2023/10/02.
+//  Copyright © 2023 FDEE. All rights reserved.
+//
+
+import Foundation
+
+enum NetworkError: Error {
+    case FAIL
+    case TIMEOUT
+    case DECODEERROR
+    case CLIENTERROR(String?) // 400
+    case AUTHENTICATION(String?) // 401
+    case NOTFOUND(String?) // 404
+    case CONFLICT(String?) // 409
+    case SERVERERROR(String?) // 500
+    
+    static func error(_ result: NetworkResult) -> NetworkError {
+        switch result.status {
+        case .TIMEOUT:
+            return .TIMEOUT
+        case .SERVER(let statusCode):
+            return serverError(statusCode: statusCode, data: result.data)
+        default:
+            return .FAIL
+        }
+    }
+    
+    static func serverError(statusCode: Int, data: Data?) -> NetworkError {
+        // MARK: Decoding 로직 필요
+        let errorMessage: String? = ""
+        switch statusCode {
+        case 400:
+            return .CLIENTERROR(errorMessage)
+        case 401:
+            return .AUTHENTICATION(errorMessage)
+        case 404:
+            return .NOTFOUND(errorMessage)
+        case 409:
+            return .CONFLICT(errorMessage)
+        case 500:
+            return .SERVERERROR(errorMessage)
+        default:
+            return .FAIL
+        }
+    }
+}

--- a/Project_Timer/Network/NetworkInterceptor.swift
+++ b/Project_Timer/Network/NetworkInterceptor.swift
@@ -64,12 +64,15 @@ extension NetworkInterceptor {
               let password = KeyChain.shared.get(key: .password) else { return }
         let loginInfo = TestUserLoginInfo(username: username, password: password)
         let network: TestServerAuthFetchable = NetworkController(network: Network())
-        network.login(userInfo: loginInfo) { status, token in
-            guard status == .SUCCESS, let token = token else {
+        network.login(userInfo: loginInfo) { result in
+            switch result {
+            case .success(let token):
+                completion(token)
+            case .failure(let error):
+                let message = error.alertMessage
+                print("title: \(error.title)/nmessage: \(error.message)")
                 completion(nil)
-                return
             }
-            completion(token)
         }
     }
 }

--- a/Project_Timer/Network/NetworkProtocols.swift
+++ b/Project_Timer/Network/NetworkProtocols.swift
@@ -41,7 +41,7 @@ protocol TestServerAuthFetchable {
 }
 
 protocol TestServerDailyFetchable {
-    func uploadDailys(dailys: [Daily], completion: @escaping (NetworkStatus) -> Void)
+    func uploadDailys(dailys: [Daily], completion: @escaping (Result<Bool, NetworkError>) -> Void)
     func getDailys(completion: @escaping (Result<[Daily], NetworkError>) -> Void)
 }
 

--- a/Project_Timer/Network/NetworkProtocols.swift
+++ b/Project_Timer/Network/NetworkProtocols.swift
@@ -15,41 +15,41 @@ protocol NetworkFetchable {
 }
 
 protocol VersionFetchable {
-    func getAppstoreVersion(completion: @escaping (NetworkStatus, String?) -> Void)
+    func getAppstoreVersion(completion: @escaping (Result<String, NetworkError>) -> Void)
 }
 
 protocol TiTiFunctionsFetchable {
-    func getTiTiFunctions(completion: @escaping (NetworkStatus, [FunctionInfo]) -> Void)
+    func getTiTiFunctions(completion: @escaping (Result<[FunctionInfo], NetworkError>) -> Void)
 }
 
 protocol UpdateHistoryFetchable {
-    func getUpdateHistorys(completion: @escaping (NetworkStatus, [UpdateInfo]) -> Void)
+    func getUpdateHistorys(completion: @escaping (Result<[UpdateInfo], NetworkError>) -> Void)
 }
 
 protocol YoutubeLinkFetchable {
-    func getYoutubeLink(completion: @escaping (NetworkStatus, YoutubeLinkInfo?) -> Void)
+    func getYoutubeLink(completion: @escaping (Result<YoutubeLinkInfo, NetworkError>) -> Void)
 }
 
 protocol SurveysFetchable {
-    func getSurveys(completion: @escaping (NetworkStatus, [SurveyInfo]) -> Void)
+    func getSurveys(completion: @escaping (Result<[SurveyInfo], NetworkError>) -> Void)
 }
 
 // MARK: TestServer
 protocol TestServerAuthFetchable {
-    func signup(userInfo: TestUserSignupInfo, completion: @escaping (NetworkStatus, String?) -> Void)
-    func login(userInfo: TestUserLoginInfo, completion: @escaping (NetworkStatus, String?) -> Void)
+    func signup(userInfo: TestUserSignupInfo, completion: @escaping (Result<String, NetworkError>) -> Void)
+    func login(userInfo: TestUserLoginInfo, completion: @escaping (Result<String, NetworkError>) -> Void)
 }
 
 protocol TestServerDailyFetchable {
     func uploadDailys(dailys: [Daily], completion: @escaping (NetworkStatus) -> Void)
-    func getDailys(completion: @escaping (NetworkStatus, [Daily]) -> Void)
+    func getDailys(completion: @escaping (Result<[Daily], NetworkError>) -> Void)
 }
 
 protocol TestServerSyncLogFetchable {
-    func getSyncLog(completion: @escaping (NetworkStatus, SyncLog?) -> Void)
+    func getSyncLog(completion: @escaping (Result<SyncLog, NetworkError>) -> Void)
 }
 
 protocol TestServerRecordTimesFetchable {
-    func uploadRecordTimes(recordTimes: RecordTimes, completion: @escaping (NetworkStatus) -> Void)
-    func getRecordTimes(completion: @escaping (NetworkStatus, RecordTimes?) -> Void)
+    func uploadRecordTimes(recordTimes: RecordTimes, completion: @escaping (Result<Bool, NetworkError>) -> Void)
+    func getRecordTimes(completion: @escaping (Result<RecordTimes, NetworkError>) -> Void)
 }

--- a/Project_Timer/Network/NetworkProtocols.swift
+++ b/Project_Timer/Network/NetworkProtocols.swift
@@ -46,7 +46,7 @@ protocol TestServerDailyFetchable {
 }
 
 protocol TestServerSyncLogFetchable {
-    func getSyncLog(completion: @escaping (Result<SyncLog, NetworkError>) -> Void)
+    func getSyncLog(completion: @escaping (Result<SyncLog?, NetworkError>) -> Void)
 }
 
 protocol TestServerRecordTimesFetchable {

--- a/Project_Timer/Network/NetworkResult.swift
+++ b/Project_Timer/Network/NetworkResult.swift
@@ -1,0 +1,14 @@
+//
+//  NetworkResult.swift
+//  Project_Timer
+//
+//  Created by Kang Minsang on 2023/10/02.
+//  Copyright © 2023 FDEE. All rights reserved.
+//
+
+import Foundation
+
+struct NetworkResult {
+    let status: NetworkStatus
+    let data: Data?
+}

--- a/Project_Timer/Network/NetworkStatus.swift
+++ b/Project_Timer/Network/NetworkStatus.swift
@@ -8,35 +8,28 @@
 
 import Foundation
 
-struct NetworkResult {
-    let status: NetworkStatus
-    let data: Data?
-}
-
-enum NetworkStatus: String {
-    case SUCCESS // 200~204
-    case NOTMODIFIED // 304
-    case CLIENTERROR // 400
-    case AUTHENTICATION // 401
-    case NOTFOUND // 404
-    case CONFLICT // 409
-    case SERVERERROR // 500
-    case DECODEERROR // -1
+enum NetworkStatus {
+    case SUCCESS // 200~204, 304
+    case FAIL // -1
     case TIMEOUT // -2
+    case SERVER(Int)
     
     static func status(_ statusCode: Int) -> NetworkStatus {
         switch statusCode {
-        case 200: return .SUCCESS
-        case 201: return .SUCCESS
-        case 204: return .SUCCESS
+        case (200...209): return .SUCCESS
         case 304: return .SUCCESS
-        case 401: return .AUTHENTICATION
-        case 404: return .NOTFOUND
-        case 409: return .CONFLICT
-        case 500: return .SERVERERROR
-        case -1: return .DECODEERROR
-        case -2: return .TIMEOUT
-        default: return .CLIENTERROR
+        default: return .SERVER(statusCode)
         }
     }
 }
+
+
+
+//case SUCCESS // 200~204, 304
+//case CLIENTERROR // 400
+//case AUTHENTICATION // 401
+//case NOTFOUND // 404
+//case CONFLICT // 409
+//case SERVERERROR // 500
+//case DECODEERROR // -1
+//case TIMEOUT // -2

--- a/Project_Timer/Network/NetworkStatus.swift
+++ b/Project_Timer/Network/NetworkStatus.swift
@@ -22,14 +22,3 @@ enum NetworkStatus {
         }
     }
 }
-
-
-
-//case SUCCESS // 200~204, 304
-//case CLIENTERROR // 400
-//case AUTHENTICATION // 401
-//case NOTFOUND // 404
-//case CONFLICT // 409
-//case SERVERERROR // 500
-//case DECODEERROR // -1
-//case TIMEOUT // -2

--- a/Project_Timer/Network/NetworkStatus.swift
+++ b/Project_Timer/Network/NetworkStatus.swift
@@ -9,19 +9,20 @@
 import Foundation
 
 struct NetworkResult {
-    let data: Data?
     let status: NetworkStatus
+    let data: Data?
 }
 
 enum NetworkStatus: String {
     case SUCCESS // 200~204
     case NOTMODIFIED // 304
-    case FAIL // 400
+    case CLIENTERROR // 400
     case AUTHENTICATION // 401
     case NOTFOUND // 404
     case CONFLICT // 409
     case SERVERERROR // 500
     case DECODEERROR // -1
+    case TIMEOUT // -2
     
     static func status(_ statusCode: Int) -> NetworkStatus {
         switch statusCode {
@@ -34,7 +35,8 @@ enum NetworkStatus: String {
         case 409: return .CONFLICT
         case 500: return .SERVERERROR
         case -1: return .DECODEERROR
-        default: return .FAIL
+        case -2: return .TIMEOUT
+        default: return .CLIENTERROR
         }
     }
 }

--- a/Project_Timer/Setting/Main/SettingVM.swift
+++ b/Project_Timer/Setting/Main/SettingVM.swift
@@ -77,10 +77,14 @@ final class SettingVM {
         
         self.cells = cells
         
-        NetworkController(network: Network()).getAppstoreVersion { [weak self] status, version in
-            guard status == .SUCCESS, let version = version else { return }
-            versionCell.updateSubTitle(to: "Latest version".localized()+": \(version)")
-            self?.lastestVersionFetched = true
+        NetworkController(network: Network()).getAppstoreVersion { [weak self] result in
+            switch result {
+            case .success(let version):
+                versionCell.updateSubTitle(to: "Latest version".localized()+": \(version)")
+                self?.lastestVersionFetched = true
+            case .failure(let error):
+                print(error.alertMessage)
+            }
         }
     }
 }

--- a/Project_Timer/Setting/Service/SettingFunctionsList/SettingFunctionsListVM.swift
+++ b/Project_Timer/Setting/Service/SettingFunctionsList/SettingFunctionsListVM.swift
@@ -24,31 +24,23 @@ final class SettingFunctionsListVM {
     }
     
     private func configureInfos() {
-        self.networkController.getTiTiFunctions { [weak self] status, infos in
-            switch status {
-            case .SUCCESS:
-                self?.infos = infos
-            case .DECODEERROR:
-                self?.warning = (title: "네트워크 에러", text: "최신 버전으로 업데이트 해주세요")
-            default:
-                self?.warning = (title: "네트워크 에러", text: "네트워크를 확인 후 다시 시도해주세요")
+        self.networkController.getTiTiFunctions { [weak self] result in
+            switch result {
+            case .success(let functionInfos):
+                self?.infos = functionInfos
+            case .failure(let error):
+                self?.warning = error.alertMessage
             }
         }
     }
     
     private func configureYoutubeLink() {
-        self.networkController.getYoutubeLink { [weak self] status, info in
-            switch status {
-            case .SUCCESS:
-                guard let info = info else {
-                    self?.warning = (title: "네트워크 에러", text: "네트워크를 확인 후 다시 시도해주세요")
-                    return
-                }
-                self?.youtubeLink = info.url.value
-            case .DECODEERROR:
-                self?.warning = (title: "네트워크 에러", text: "최신 버전으로 업데이트 해주세요")
-            default:
-                self?.warning = (title: "네트워크 에러", text: "네트워크를 확인 후 다시 시도해주세요")
+        self.networkController.getYoutubeLink { [weak self] result in
+            switch result {
+            case .success(let youtubeLinkInfo):
+                self?.youtubeLink = youtubeLinkInfo.url.value
+            case .failure(let error):
+                self?.warning = error.alertMessage
             }
         }
     }

--- a/Project_Timer/Setting/Service/SettingTiTiLab/SettingTiTiLabVM.swift
+++ b/Project_Timer/Setting/Service/SettingTiTiLab/SettingTiTiLabVM.swift
@@ -20,14 +20,12 @@ final class SettingTiTiLabVM {
     }
     
     private func configureInfos() {
-        self.networkController.getSurveys { [weak self] status, infos in
-            switch status {
-            case .SUCCESS:
-                self?.infos = infos
-            case .DECODEERROR:
-                self?.warning = (title: "네트워크 에러", text: "최신 버전으로 업데이트 해주세요")
-            default:
-                self?.warning = (title: "네트워크 에러", text: "네트워크를 확인 후 다시 시도해주세요")
+        self.networkController.getSurveys { [weak self] result in
+            switch result {
+            case .success(let surveyInfos):
+                self?.infos = surveyInfos
+            case .failure(let error):
+                self?.warning = error.alertMessage
             }
         }
     }

--- a/Project_Timer/Setting/Service/SettingTiTiLab/TestServer/SignupLoginVC.swift
+++ b/Project_Timer/Setting/Service/SettingTiTiLab/TestServer/SignupLoginVC.swift
@@ -247,10 +247,11 @@ extension SignupLoginVC {
         self.viewModel.$loginSuccess
             .receive(on: DispatchQueue.main)
             .sink { [weak self] loginSuccess in
-                if loginSuccess {
-                    self?.showAlertWithOKAfterHandler(title: "SUCCESS", text: "") { [weak self] in
-                        self?.navigationController?.popViewController(animated: true)
-                    }
+                guard loginSuccess else { return }
+                
+                let title: String = self?.viewModel.isLogin == true ? "Login Success".localized() : "Signup Success".localized()
+                self?.showAlertWithOKAfterHandler(title: title, text: "") { [weak self] in
+                    self?.navigationController?.popViewController(animated: true)
                 }
             }
             .store(in: &self.cancellables)

--- a/Project_Timer/Setting/Service/SettingTiTiLab/TestServer/SignupLoginVM.swift
+++ b/Project_Timer/Setting/Service/SettingTiTiLab/TestServer/SignupLoginVM.swift
@@ -53,6 +53,9 @@ final class SignupLoginVM {
                     // login 관련 error message 추가
                 case .CLIENTERROR(_):
                     self?.alert = (title: "Login Fail".localized(), text: "Please enter your nickname and password correctly".localized())
+                    // TestServer 에러핸들링 이슈로 404코드 추가
+                case .NOTFOUND(_):
+                    self?.alert = (title: "Login Fail".localized(), text: "Please enter your nickname and password correctly".localized())
                 default:
                     self?.alert = error.alertMessage
                 }

--- a/Project_Timer/Setting/Service/SettingTiTiLab/TestServer/SignupLoginVM.swift
+++ b/Project_Timer/Setting/Service/SettingTiTiLab/TestServer/SignupLoginVM.swift
@@ -24,36 +24,38 @@ final class SignupLoginVM {
     
     func signup(info: TestUserSignupInfo) {
         self.loadingText = "Waiting for Signup..."
-        self.network.signup(userInfo: info) { [weak self] status, token in
+        self.network.signup(userInfo: info) { [weak self] result in
             self?.loadingText = nil
-            switch status {
-            case .SUCCESS:
-                guard let token = token else {
-                    self?.alert = (title: "Network Error", text: "invalid token value")
-                    return
-                }
+            switch result {
+            case .success(let token):
                 self?.saveUserInfo(username: info.username, password: info.password, token: token)
-            case .CONFLICT:
-                self?.alert = (title: "CONFLICT", text: "need another infos")
-            default:
-                self?.alert = (title: "FAIL", text: "\(status.rawValue)")
+            case .failure(let error):
+                switch error {
+                    // signup 관련 error message 추가
+                case .CLIENTERROR(_):
+                    self?.alert = (title: "Signup Error".localized(), text: "Please enter at least 5 chars and correct email value".localized())
+                default:
+                    self?.alert = error.alertMessage
+                }
             }
         }
     }
     
     func login(info: TestUserLoginInfo) {
         self.loadingText = "Waiting for Login..."
-        self.network.login(userInfo: info) { [weak self] status, token in
+        self.network.login(userInfo: info) { [weak self] result in
             self?.loadingText = nil
-            switch status {
-            case .SUCCESS:
-                guard let token = token else {
-                    self?.alert = (title: "Network Error", text: "invalid token value")
-                    return
-                }
+            switch result {
+            case .success(let token):
                 self?.saveUserInfo(username: info.username, password: info.password, token: token)
-            default:
-                self?.alert = (title: "FAIL", text: "\(status.rawValue)")
+            case .failure(let error):
+                switch error {
+                    // login 관련 error message 추가
+                case .CLIENTERROR(_):
+                    self?.alert = (title: "Login Error".localized(), text: "Please enter your nickname and password correctly".localized())
+                default:
+                    self?.alert = error.alertMessage
+                }
             }
         }
     }

--- a/Project_Timer/Setting/Service/SettingTiTiLab/TestServer/SignupLoginVM.swift
+++ b/Project_Timer/Setting/Service/SettingTiTiLab/TestServer/SignupLoginVM.swift
@@ -33,7 +33,7 @@ final class SignupLoginVM {
                 switch error {
                     // signup 관련 error message 추가
                 case .CLIENTERROR(_):
-                    self?.alert = (title: "Signup Error".localized(), text: "Please enter at least 5 chars and correct email value".localized())
+                    self?.alert = (title: "Signup Error".localized(), text: "Please check your nickname or email (at least 5 characters)".localized())
                 default:
                     self?.alert = error.alertMessage
                 }
@@ -52,7 +52,7 @@ final class SignupLoginVM {
                 switch error {
                     // login 관련 error message 추가
                 case .CLIENTERROR(_):
-                    self?.alert = (title: "Login Error".localized(), text: "Please enter your nickname and password correctly".localized())
+                    self?.alert = (title: "Login Fail".localized(), text: "Please enter your nickname and password correctly".localized())
                 default:
                     self?.alert = error.alertMessage
                 }

--- a/Project_Timer/Setting/Service/SettingTiTiLab/TestServer/SyncDailys/SyncDailysVC.swift
+++ b/Project_Timer/Setting/Service/SettingTiTiLab/TestServer/SyncDailys/SyncDailysVC.swift
@@ -100,6 +100,7 @@ extension SyncDailysVC {
         self.viewModel?.$error
             .receive(on: DispatchQueue.main)
             .sink(receiveValue: { [weak self] error in
+                LoadingIndicator.hideLoading()
                 guard let error = error else { return }
                 self?.showAlertWithOK(title: error.title, text: error.text)
             })

--- a/Project_Timer/Setting/Service/SettingTiTiLab/TestServer/SyncDailys/SyncDailysVM.swift
+++ b/Project_Timer/Setting/Service/SettingTiTiLab/TestServer/SyncDailys/SyncDailysVM.swift
@@ -62,7 +62,7 @@ extension SyncDailysVM {
                     if let message = message {
                         print("[upload Dailys ERROR] \(message)")
                     }
-                    self?.error = (title: "Upload Fail".localized(), text: "Please update to the latest version".localized())
+                    self?.error = (title: "Upload Error".localized(), text: "Please update to the latest version of the app".localized())
                 default:
                     self?.error = error.alertMessage
                 }
@@ -86,7 +86,7 @@ extension SyncDailysVM {
                     if let message = message {
                         print("[upload Recordtime ERROR] \(message)")
                     }
-                    self?.error = (title: "Upload Fail".localized(), text: "Please update to the latest version".localized())
+                    self?.error = (title: "Upload Error".localized(), text: "Please update to the latest version of the app".localized())
                 default:
                     self?.error = error.alertMessage
                 }
@@ -114,7 +114,7 @@ extension SyncDailysVM {
                     if let message = message {
                         print("[get Dailys ERROR] \(message)")
                     }
-                    self?.error = (title: "Download Fail".localized(), text: "Please update to the latest version".localized())
+                    self?.error = (title: "Download Error".localized(), text: "Please update to the latest version of the app".localized())
                 default:
                     self?.error = error.alertMessage
                 }
@@ -138,7 +138,7 @@ extension SyncDailysVM {
                     if let message = message {
                         print("[get RecordTimes ERROR] \(message)")
                     }
-                    self?.error = (title: "Download Fail".localized(), text: "Please update to the latest version".localized())
+                    self?.error = (title: "Download Error".localized(), text: "Please update to the latest version of the app".localized())
                 default:
                     self?.error = error.alertMessage
                 }
@@ -154,7 +154,7 @@ extension SyncDailysVM {
             self?.loading = false
             switch result {
             case .success(let syncLog):
-                if (afterUploaded) {
+                if let syncLog = syncLog, afterUploaded {
                     self?.saveLastUploadedDate(to: syncLog.updatedAt)
                     self?.targetDailys = []
                     self?.saveDailysSuccess = true
@@ -166,7 +166,7 @@ extension SyncDailysVM {
                     if let message = message {
                         print("[get SyncLog ERROR] \(message)")
                     }
-                    self?.error = (title: "Download Fail".localized(), text: "Please update to the latest version".localized())
+                    self?.error = (title: "Download Error".localized(), text: "Please update to the latest version of the app".localized())
                 default:
                     self?.error = error.alertMessage
                 }

--- a/Project_Timer/Setting/UpdateHistory/SettingUpdateHistoryVM.swift
+++ b/Project_Timer/Setting/UpdateHistory/SettingUpdateHistoryVM.swift
@@ -20,16 +20,14 @@ final class SettingUpdateHistoryVM {
     }
     
     private func configureInfos() {
-        self.networkController.getUpdateHistorys { [weak self] status, infos in
-            switch status {
-            case .SUCCESS:
-                self?.infos = infos.sorted(by: {
+        self.networkController.getUpdateHistorys { [weak self] result in
+            switch result {
+            case .success(let updateInfo):
+                self?.infos = updateInfo.sorted(by: {
                     $0.version.value.compare($1.version.value, options: .numeric) == .orderedDescending
                 })
-            case .DECODEERROR:
-                self?.warning = (title: "네트워크 에러", text: "최신 버전으로 업데이트 해주세요")
-            default:
-                self?.warning = (title: "네트워크 에러", text: "네트워크를 확인 후 다시 시도해주세요")
+            case .failure(let error):
+                self?.warning = error.alertMessage
             }
         }
     }

--- a/Project_Timer/en.lproj/Localizable.strings
+++ b/Project_Timer/en.lproj/Localizable.strings
@@ -322,3 +322,19 @@
 "password" = "password";
 "Sign up" = "Sign up";
 "Log in" = "Log in";
+
+"Network Error" = "Network Error";
+"Network Timeout" = "Network Timeout";
+"Network Fetch Error" = "Network Fetch Error";
+"Authentication Error" = "Authentication Error";
+"Signup Error" = "Signup Error";
+"Server Error" = "Server Error";
+"Login Error" = "Login Error";
+
+"Please check the network and try again" = "Please check the network and try again";
+"Please update to the latest version" = "Please update to the latest version";
+"Please log in again" = "Please log in again";
+"Please enter your nickname or email in a different value" = "Please enter other information";
+"The server encountered an error. Please try again in a few minutes" = "The server encountered an error. Please try again in a few minutes";
+"Please enter at least 5 chars and correct email value" = "Please enter at least 5 chars and correct email value";
+"Please enter your nickname and password correctly" = "Please enter your nickname and password correctly";

--- a/Project_Timer/en.lproj/Localizable.strings
+++ b/Project_Timer/en.lproj/Localizable.strings
@@ -330,6 +330,10 @@
 "Signup Error" = "Signup Error";
 "Server Error" = "Server Error";
 "Login Error" = "Login Error";
+"Upload Fail" = "Upload Fail";
+"Download Fail" = "Download Fail";
+"Signup Success" = "Signup Success";
+"Login Success" = "Login Success";
 
 "Please check the network and try again" = "Please check the network and try again";
 "Please update to the latest version" = "Please update to the latest version";

--- a/Project_Timer/en.lproj/Localizable.strings
+++ b/Project_Timer/en.lproj/Localizable.strings
@@ -329,16 +329,16 @@
 "Authentication Error" = "Authentication Error";
 "Signup Error" = "Signup Error";
 "Server Error" = "Server Error";
-"Login Error" = "Login Error";
-"Upload Fail" = "Upload Fail";
-"Download Fail" = "Download Fail";
+"Login Fail" = "Login Fail";
+"Upload Error" = "Upload Error";
+"Download Error" = "Download Error";
 "Signup Success" = "Signup Success";
 "Login Success" = "Login Success";
 
 "Please check the network and try again" = "Please check the network and try again";
-"Please update to the latest version" = "Please update to the latest version";
+"Please update to the latest version of the app" = "Please update to the latest version of the app";
 "Please log in again" = "Please log in again";
 "Please enter your nickname or email in a different value" = "Please enter other information";
-"The server encountered an error. Please try again in a few minutes" = "The server encountered an error. Please try again in a few minutes";
-"Please enter at least 5 chars and correct email value" = "Please enter at least 5 chars and correct email value";
+"The server something went wrong. Please try again in a few minutes" = "The server something went wrong. Please try again in a few minutes";
+"Please check your nickname or email (at least 5 characters)" = "Please check your nickname or email (at least 5 characters)";
 "Please enter your nickname and password correctly" = "Please enter your nickname and password correctly";

--- a/Project_Timer/ko.lproj/Localizable.strings
+++ b/Project_Timer/ko.lproj/Localizable.strings
@@ -333,16 +333,16 @@
 "Authentication Error" = "인증정보 오류";
 "Signup Error" = "회원가입 불가";
 "Server Error" = "서버 오류";
-"Login Error" = "로그인 불가";
-"Upload Fail" = "업로드 실패";
-"Download Fail" = "다운로드 실패";
+"Login Fail" = "로그인 실패";
+"Upload Error" = "업로드 오류";
+"Download Error" = "다운로드 오류";
 "Signup Success" = "회원가입 성공";
 "Login Success" = "로그인 성공";
 
 "Please check the network and try again" = "네트워크를 확인 후 다시 시도해주세요";
-"Please update to the latest version" = "최신 버전으로 업데이트를 해주세요";
+"Please update to the latest version of the app" = "최신 버전의 앱으로 업데이트를 해주세요";
 "Please log in again" = "다시 로그인해주세요";
 "Please enter your nickname or email in a different value" = "닉네임, 또는 이메일을 다른값으로 입력해주세요";
-"The server encountered an error. Please try again in a few minutes" = "서버에 오류가 발생했습니다. 잠시 후 다시 시도해주세요";
-"Please enter at least 5 chars and correct email value" = "5자리 이상, 정확한 email 값을 입력해주세요";
+"The server something went wrong. Please try again in a few minutes" = "서버에 오류가 발생했습니다. 잠시 후 다시 시도해주세요";
+"Please check your nickname or email (at least 5 characters)" = "닉네임 또는 이메일을 확인해주세요 (5자리 이상)";
 "Please enter your nickname and password correctly" = "닉네임과 패스워드를 정확히 입력해주세요";

--- a/Project_Timer/ko.lproj/Localizable.strings
+++ b/Project_Timer/ko.lproj/Localizable.strings
@@ -326,3 +326,19 @@
 "password" = "비밀번호";
 "Sign up" = "회원가입";
 "Log in" = "로그인";
+
+"Network Error" = "네트워크 오류";
+"Network Timeout" = "네트워크 시간초과";
+"Network Fetch Error" = "네트워크 수신불가";
+"Authentication Error" = "인증정보 오류";
+"Signup Error" = "회원가입 불가";
+"Server Error" = "서버 오류";
+"Login Error" = "로그인 불가";
+
+"Please check the network and try again" = "네트워크를 확인 후 다시 시도해주세요";
+"Please update to the latest version" = "최신 버전으로 업데이트를 해주세요";
+"Please log in again" = "다시 로그인해주세요";
+"Please enter your nickname or email in a different value" = "닉네임, 또는 이메일을 다른값으로 입력해주세요";
+"The server encountered an error. Please try again in a few minutes" = "서버에 오류가 발생했습니다. 잠시 후 다시 시도해주세요";
+"Please enter at least 5 chars and correct email value" = "5자리 이상, 정확한 email 값을 입력해주세요";
+"Please enter your nickname and password correctly" = "닉네임과 패스워드를 정확히 입력해주세요";

--- a/Project_Timer/ko.lproj/Localizable.strings
+++ b/Project_Timer/ko.lproj/Localizable.strings
@@ -334,6 +334,10 @@
 "Signup Error" = "회원가입 불가";
 "Server Error" = "서버 오류";
 "Login Error" = "로그인 불가";
+"Upload Fail" = "업로드 실패";
+"Download Fail" = "다운로드 실패";
+"Signup Success" = "회원가입 성공";
+"Login Success" = "로그인 성공";
 
 "Please check the network and try again" = "네트워크를 확인 후 다시 시도해주세요";
 "Please update to the latest version" = "최신 버전으로 업데이트를 해주세요";


### PR DESCRIPTION
### 개요
- Issue:  #103 
- background: TestServer 로그인 & 회원가입 기능제공이 길어지면서 네트워킹 오류문구 개선의 필요성을 느낌, 따라서 NetworkError 핸들링의 개선과 Alert Message 문구를 정리하였다.

---

### 변경사항
- [x] NetworkStatus 수정
- [x] NetworkResult 수정
- [x] NetworkError 생성
- [x] NetworkError값에 따른 Alert Message 문구조합 생성
- [x] VM내에서 .success, .fail 여부에 따라 알맞은 Alert Message를 표시할 수 있도록 개선

### Network 수신부터 VM까지의 전달 고민
- Network를 통해 필요한 정보를 VM으로 전달하는 것이 중요
- 하지만 error가 발생할 수 있고, 사용자 입장에서 어떤 error가 발생했는지 인지되는것도 중요
- 따라서 VM에서는 success, fail 여부에 따라 필요한 정보, 또는 어떤 error가 발생했는지를 받을 수 있는 구조가 필요하였다.
- 추가적으로, error는 statusCode 값을 기준으로 분기처리가 되지만, server에서 보낸 error message값 또한 수신받을 수 있는 구조가 필요하였다.
- 따라서 고민을 통해 `Network` -> `NetworkStatus` 생성 -> `NetworkResult` 생성 및 전달 -> `Result<필요값, NetworkError>` 전달 형식으로 개선하였다.

### NetworkStatus
- NetworkStatus는 네트워크 자체의 상태를 나타낸다.
- statusCode가 없는 TIMEOUT 와 FAIL 형태를 포함하여 SUCCESS와 statusCode를 지닌 형태로 구분된다.
```swift
enum NetworkStatus {
    case SUCCESS // 200~204, 304
    case FAIL // -1
    case TIMEOUT // -2
    case SERVER(Int)
    
    static func status(_ statusCode: Int) -> NetworkStatus {
        switch statusCode {
        case (200...209): return .SUCCESS
        case 304: return .SUCCESS
        default: return .SERVER(statusCode)
        }
    }
}
```

### NetworkResult
- NetworkStatus 값과 server로부터 받은 Data를 지닌 형태이다.
- 네트워킹 결과가 성공이여도 받을 Data가 없을 수 있기에 NetworkStatus와 Data? 형태가 되었다.
```swift
struct NetworkResult {
    let status: NetworkStatus
    let data: Data?
}
```

### NetworkError
- NetworkResult로부터 `statusCode` 및 `TIMEOUT`, `FAIL` 여부를 받아 `세부적인 에러형태로 분기처리`되는 형태이다.
- `VM`입장에서는 `성공했을 시 필요한 값`, `실패했을 시 어떤 실패`인지만 필요하다.
- `Network` 입장에서는 `statusCode 값과 Data만 전달`하는것이 바람직하다.
- 따라서 `NetworkResult`를 토대로 `NetworkError`가 생성되는 구조가 되었다.
- 추가로 statusCode 만으로 에러분기처리가 아닌 error message를 Data 형태로 수신되는점도 고려하여 message를 지닐 수 있는 형태로 구조를 개선하였다.
```swift
enum NetworkError: Error {
    case FAIL
    case TIMEOUT
    case DECODEERROR
    case CLIENTERROR(String?) // 400
    case AUTHENTICATION(String?) // 401
    case NOTFOUND(String?) // 404
    case CONFLICT(String?) // 409
    case SERVERERROR(String?) // 500
    
    static func error(_ result: NetworkResult) -> NetworkError {
        switch result.status {
        case .TIMEOUT:
            return .TIMEOUT
        case .SERVER(let statusCode):
            return serverError(statusCode: statusCode, data: result.data)
        default:
            return .FAIL
        }
    }
    
    static func serverError(statusCode: Int, data: Data?) -> NetworkError {
        // MARK: Decoding 로직 필요
        let errorMessage: String? = ""
        switch statusCode {
        case 400:
            return .CLIENTERROR(errorMessage)
        case 401:
            return .AUTHENTICATION(errorMessage)
        case 404:
            return .NOTFOUND(errorMessage)
        case 409:
            return .CONFLICT(errorMessage)
        case 500:
            return .SERVERERROR(errorMessage)
        default:
            return .FAIL
        }
    }
}
```

### Alert Message
- statusCode가 400인 CLIENTERROR 형태가 아닌 대부분의 ERROR의 경우 공통적인 에러형태이다.
- 따라서 이런 공통적인 에러메세지를 VM 단에서 일일이 처리하여 코드중복되는 현상을 방지하고자 NetworkError 내에서 alertMessage 쌍을 제공하는 식으로 구조를 개선하였다.
- VM 내에서는 특이사항의 경우만 Alert Message를 핸들링하고 이외에는 NetworkError 타입에 따른 공통적인 Alert Message를 표시하면 된다.
```swift
/// 범용적으로 표시될 수 있는 alert title 값, CLIENTERROR의 경우 VM에서 처리
var title: String {
    switch self {
    case .FAIL:
        return "Network Error".localized()
    case .TIMEOUT:
        return "Network Timeout".localized()
    case .DECODEERROR:
        return "Network Fetch Error".localized()
    case .AUTHENTICATION(_):
        return "Authentication Error".localized()
    case .NOTFOUND(_):
        return "Network Fetch Error".localized()
    case .CONFLICT(_):
        return "Signup Error".localized()
    case .SERVERERROR(_):
        return "Server Error".localized()
    default:
        return "Network Error".localized()
    }
}

/// 범용적으로 표시될 수 있는 alert message 값, CLIENTERROR의 경우 VM에서 처리
var message: String {
    switch self {
    case .FAIL:
        return "Please check the network and try again".localized()
    case .TIMEOUT:
        return "Please check the network and try again".localized()
    case .DECODEERROR:
        return "Please update to the latest version of the app".localized()
    case .AUTHENTICATION(_):
        return "Please log in again".localized()
    case .NOTFOUND(_):
        return "Please update to the latest version of the app".localized()
    case .CONFLICT(_):
        return "Please enter your nickname or email in a different value".localized()
    case .SERVERERROR(_):
        return "The server something went wrong. Please try again in a few minutes".localized()
    default:
        return "Please check the network and try again".localized()
    }
}

/// 범용적으로 표시되는 alert문구의 조합을 반환
var alertMessage: (title: String, text: String) {
    return (title: self.title, text: self.message)
}
```

### VM 내 Result<성공값, NetworkError> 핸들링
- VM 내에서는 success, fail 여부로 분기처리된다.
- fail 내에서는 NetworkError 타입에 따라 분기처리되어 Alert Message를 표시한다.
- CLIENTERROR 타입의 경우 요청한 API별로, VC별로 에러메세지가 달라질 수 있기에 VM 내에서 Alert Message를 처리한다.
```swift
func signup(info: TestUserSignupInfo) {
    self.loadingText = "Waiting for Signup..."
    self.network.signup(userInfo: info) { [weak self] result in
        self?.loadingText = nil
        switch result {
        case .success(let token):
            self?.saveUserInfo(username: info.username, password: info.password, token: token)
        case .failure(let error):
            switch error {
                // signup 관련 error message 추가
            case .CLIENTERROR(_):
                self?.alert = (title: "Signup Error".localized(), text: "Please check your nickname or email (at least 5 characters)".localized())
            default:
                self?.alert = error.alertMessage
            }
        }
    }
}
```
