### PR TITLE
Login화면 키보드 표시에 따른 화면이동 구현

### DIFF
--- a/Project_Timer.xcodeproj/project.pbxproj
+++ b/Project_Timer.xcodeproj/project.pbxproj
@@ -2056,7 +2056,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = Project_Timer/Project_Timer.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_TEAM = 2C96RNDN63;
 				"ENABLE_HARDENED_RUNTIME[sdk=macosx*]" = YES;
 				INFOPLIST_FILE = Project_Timer/Info.plist;
@@ -2295,7 +2295,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = Project_Timer/Project_Timer.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_TEAM = 2C96RNDN63;
 				"ENABLE_HARDENED_RUNTIME[sdk=macosx*]" = YES;
 				INFOPLIST_FILE = Project_Timer/Info.plist;
@@ -2322,7 +2322,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = Project_Timer/Project_Timer.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_TEAM = 2C96RNDN63;
 				"ENABLE_HARDENED_RUNTIME[sdk=macosx*]" = YES;
 				INFOPLIST_FILE = Project_Timer/Info.plist;

--- a/Project_Timer.xcodeproj/project.pbxproj
+++ b/Project_Timer.xcodeproj/project.pbxproj
@@ -51,6 +51,7 @@
 		870E11762A0E226D00CFA77C /* CalendarWidgetData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 870E11742A0E226D00CFA77C /* CalendarWidgetData.swift */; };
 		870E117B2A0F7DEE00CFA77C /* CalendarWidgetCellData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 870E117A2A0F7DEE00CFA77C /* CalendarWidgetCellData.swift */; };
 		870E117C2A0F7EF000CFA77C /* CalendarWidgetCellData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 870E117A2A0F7DEE00CFA77C /* CalendarWidgetCellData.swift */; };
+		870E85012AD67E46000511BD /* KeyboardResponder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 870E85002AD67E46000511BD /* KeyboardResponder.swift */; };
 		87163DC82ACAF2E8008D4072 /* NetworkError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87163DC72ACAF2E8008D4072 /* NetworkError.swift */; };
 		87163DCA2ACAF89B008D4072 /* NetworkResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87163DC92ACAF89B008D4072 /* NetworkResult.swift */; };
 		87168D99299A819F003ED502 /* UserDefaults+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 875C98C82871BFCF008F7ADD /* UserDefaults+Extension.swift */; };
@@ -352,6 +353,7 @@
 		870C70722AD51BEB00024CAC /* PredicateChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PredicateChecker.swift; sourceTree = "<group>"; };
 		870E11742A0E226D00CFA77C /* CalendarWidgetData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarWidgetData.swift; sourceTree = "<group>"; };
 		870E117A2A0F7DEE00CFA77C /* CalendarWidgetCellData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarWidgetCellData.swift; sourceTree = "<group>"; };
+		870E85002AD67E46000511BD /* KeyboardResponder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardResponder.swift; sourceTree = "<group>"; };
 		87163DC72ACAF2E8008D4072 /* NetworkError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkError.swift; sourceTree = "<group>"; };
 		87163DC92ACAF89B008D4072 /* NetworkResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkResult.swift; sourceTree = "<group>"; };
 		87199F432882BC430017D01A /* StandardDailyGraphView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StandardDailyGraphView.swift; sourceTree = "<group>"; };
@@ -1414,6 +1416,7 @@
 				87CAC06128B8711D0036CF24 /* FirebaseEvent.swift */,
 				8760FCB829541BE3000BCCD1 /* KeyChain.swift */,
 				870C70722AD51BEB00024CAC /* PredicateChecker.swift */,
+				870E85002AD67E46000511BD /* KeyboardResponder.swift */,
 			);
 			path = SingletonClass;
 			sourceTree = "<group>";
@@ -1780,6 +1783,7 @@
 				87DC6A4B28D010A400455A06 /* WeekTime.swift in Sources */,
 				87BE88E72AD425BE0010A84A /* LoginTextFieldView.swift in Sources */,
 				049BBA9A28AB5747005BAB1B /* TaskModifyInteractionView.swift in Sources */,
+				870E85012AD67E46000511BD /* KeyboardResponder.swift in Sources */,
 				87A48BCB27DF112B00F46D0F /* LogHomeVM.swift in Sources */,
 				87D7ED172952B69200121DE6 /* TestUserLoginInfo.swift in Sources */,
 				87199F5E28842F0E0017D01A /* CheckGraphButton.swift in Sources */,

--- a/Project_Timer/Global/Extension/Foundation/CGSize+Extension.swift
+++ b/Project_Timer/Global/Extension/Foundation/CGSize+Extension.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import UIKit
 
 extension CGSize {
     enum DeviceDetailType: CGFloat {
@@ -18,9 +19,13 @@ extension CGSize {
         case iPhoneMini = 375
     }
     
-    enum DeviceType {
-        case iPad
-        case iPhone
+    enum DeviceLandspace: CGFloat {
+        case iPad12 = 1366
+        case iPad11 = 1194
+        case iPadMini = 1133
+        case iPhoneMax = 932
+        case iPhonePro = 844
+        case iPhoneMini = 667
     }
     
     /// 가로, 세로 중 작은값
@@ -28,36 +33,37 @@ extension CGSize {
         return min(self.width, self.height)
     }
     
-    /// minLength 값을 기준으로 디바이스 형태 분기 값
-    var deviceType: DeviceType {
-        let width = minLength
-        
-        if width > DeviceDetailType.iPhoneMax.rawValue {
-            return .iPad
-        } else {
-            return .iPhone
-        }
-    }
-    
     /// minLength 값을 기준으로 디바이스 상세 형태 분기 값
     var deviceDetailType: DeviceDetailType {
-        let width = minLength
+        let min = minLength
+        let max = max(self.width, self.height)
         
         // iPad
-        if width > DeviceDetailType.iPhoneMax.rawValue {
-            if width >= DeviceDetailType.iPad12.rawValue {
-                return .iPad12
-            } else if width >= DeviceDetailType.iPad11.rawValue {
-                return .iPad11
-            } else {
-                return .iPadMini
+        if min > DeviceDetailType.iPhoneMax.rawValue {
+            switch UIDevice.current.orientation {
+            case .landscapeLeft, .landscapeRight:
+                if max >= DeviceLandspace.iPad12.rawValue {
+                    return .iPad12
+                } else if max >= DeviceLandspace.iPad11.rawValue {
+                    return .iPad11
+                } else {
+                    return .iPadMini
+                }
+            default:
+                if min >= DeviceDetailType.iPad12.rawValue {
+                    return .iPad12
+                } else if min >= DeviceDetailType.iPad11.rawValue {
+                    return .iPad11
+                } else {
+                    return .iPadMini
+                }
             }
         }
         // iPhone
         else {
-            if width >= 428 { // 428 ~ 430 이내만 iPhoneMax UI 표시
+            if min >= 428 { // 428 ~ 430 이내만 iPhoneMax UI 표시
                 return .iPhoneMax
-            } else if width >= DeviceDetailType.iPhonePro.rawValue {
+            } else if min >= DeviceDetailType.iPhonePro.rawValue {
                 return .iPhonePro
             } else {
                 return .iPhoneMini

--- a/Project_Timer/Global/SingletonClass/KeyboardResponder.swift
+++ b/Project_Timer/Global/SingletonClass/KeyboardResponder.swift
@@ -25,7 +25,7 @@ final class KeyboardResponder: ObservableObject {
     }
 
     @objc func keyBoardWillShow(notification: Notification) {
-        if let keyboardSize = (notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue {
+        if let keyboardSize = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect {
             keyboardHeight = keyboardSize.height
         }
         keyboardShow = true

--- a/Project_Timer/Global/SingletonClass/KeyboardResponder.swift
+++ b/Project_Timer/Global/SingletonClass/KeyboardResponder.swift
@@ -1,0 +1,42 @@
+//
+//  KeyboardResponder.swift
+//  Project_Timer
+//
+//  Created by Kang Minsang on 2023/10/11.
+//  Copyright © 2023 FDEE. All rights reserved.
+//
+
+import SwiftUI
+
+final class KeyboardResponder: ObservableObject {
+    private var notificationCenter: NotificationCenter
+    @Published private(set) var keyboardHeight: CGFloat = 0
+    @Published private(set) var keyboardShow: Bool = false
+    @Published private(set) var keyboardHide: Bool = false
+
+    init(center: NotificationCenter = .default) {
+        notificationCenter = center
+        notificationCenter.addObserver(self, selector: #selector(keyBoardWillShow(notification:)), name: UIResponder.keyboardWillShowNotification, object: nil)
+        notificationCenter.addObserver(self, selector: #selector(keyBoardWillHide(notification:)), name: UIResponder.keyboardWillHideNotification, object: nil)
+    }
+
+    deinit {
+        notificationCenter.removeObserver(self)
+    }
+
+    @objc func keyBoardWillShow(notification: Notification) {
+        if let keyboardSize = (notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue {
+            keyboardHeight = keyboardSize.height
+        }
+        keyboardShow = true
+    }
+
+    @objc func keyBoardWillHide(notification: Notification) {
+        keyboardHeight = 0
+        keyboardShow = false
+        keyboardHide = true
+        Timer.scheduledTimer(withTimeInterval: 0.2, repeats: false) { [weak self] _ in
+            self?.keyboardHide = false
+        }
+    }
+}

--- a/Project_Timer/LoginSignup/LoginSelect/LoginSelectView.swift
+++ b/Project_Timer/LoginSignup/LoginSelect/LoginSelectView.swift
@@ -77,9 +77,6 @@ struct LoginSelectView: View {
                     .frame(height: 58)
                 
                 ButtonsView(navigationPath: $navigationPath)
-                
-                Spacer()
-                    .frame(height: 16)
             }
             .frame(width: self.width)
         }

--- a/Project_Timer/LoginSignup/LoginView/LoginTextFieldView.swift
+++ b/Project_Timer/LoginSignup/LoginView/LoginTextFieldView.swift
@@ -30,6 +30,7 @@ struct LoginTextFieldView: View {
                 TextField("", text: $text)
                     .font(.system(size: 16, weight: .bold))
                     .foregroundStyle(.black)
+                    .accentColor(.black)
                     .placeholder(when: text.isEmpty) { // placeholder 텍스트 설정
                         Text(placeholder)
                             .font(.system(size: 16, weight: .bold))
@@ -48,6 +49,7 @@ struct LoginTextFieldView: View {
                 SecureField("", text: $text)
                     .font(.system(size: 16, weight: .bold))
                     .foregroundStyle(.black)
+                    .accentColor(.black)
                     .placeholder(when: text.isEmpty) { // placeholder 텍스트 설정
                         Text(placeholder)
                             .font(.system(size: 16, weight: .bold))

--- a/Project_Timer/LoginSignup/LoginView/LoginView.swift
+++ b/Project_Timer/LoginSignup/LoginView/LoginView.swift
@@ -12,6 +12,7 @@ struct LoginView: View {
     @EnvironmentObject var listener: LoginSignupEventListener
     @Binding var navigationPath: NavigationPath
     @State private var superViewSize: CGSize = .zero
+    @ObservedObject private var keyboard = KeyboardResponder()
     
     var body: some View {
         GeometryReader { geometry in
@@ -26,6 +27,8 @@ struct LoginView: View {
                     
                     Spacer()
                 }
+                .offset(y: keyboardOffset(keyboard.keyboardShow))
+                .animation(.easeIn(duration: keyboard.keyboardShow || keyboard.keyboardHide ? 0.2 : 0))
             }
             .onChange(of: geometry.size, perform: { value in
                 self.superViewSize = value
@@ -45,6 +48,43 @@ struct LoginView: View {
             }
         }
         .navigationTitle("")
+        .ignoresSafeArea(.keyboard)
+    }
+    
+    func keyboardOffset(_ keyboardShow: Bool) -> CGFloat {
+        if keyboardShow == false {
+            return 0
+        } else {
+            switch superViewSize.deviceDetailType {
+            case .iPhoneMini:
+                return -100
+            case .iPhonePro:
+                return -84
+            case .iPhoneMax:
+                return -54
+            case .iPadMini:
+                switch UIDevice.current.orientation {
+                case .landscapeLeft, .landscapeRight:
+                    return -225
+                default:
+                    return 0
+                }
+            case .iPad11:
+                switch UIDevice.current.orientation {
+                case .landscapeLeft, .landscapeRight:
+                    return -180
+                default:
+                    return 0
+                }
+            case .iPad12:
+                switch UIDevice.current.orientation {
+                case .landscapeLeft, .landscapeRight:
+                    return -155
+                default:
+                    return 0
+                }
+            }
+        }
     }
     
     struct ContentView: View {
@@ -80,7 +120,7 @@ struct LoginView: View {
                 FooterView(navigationPath: $navigationPath)
                 
                 Spacer()
-                    .frame(height: 30)
+                    .frame(height: 14)
             }
             .frame(width: self.width)
         }

--- a/Project_Timer/LoginSignup/LoginView/LoginView.swift
+++ b/Project_Timer/LoginSignup/LoginView/LoginView.swift
@@ -52,7 +52,7 @@ struct LoginView: View {
     }
     
     func keyboardOffset(_ keyboardShow: Bool) -> CGFloat {
-        if keyboardShow == false {
+        if keyboardShow == false || keyboard.keyboardHeight < 260 {
             return 0
         } else {
             switch superViewSize.deviceDetailType {
@@ -165,7 +165,7 @@ struct LoginView: View {
                 } label: {
                     ZStack {
                         RoundedRectangle(cornerRadius: 12)
-                            .foregroundStyle(postable ? UIColor.tintColor.toColor : Color.white)
+                            .foregroundStyle(postable ? Color.blue : Color.white)
                             .shadow(color: .gray.opacity(0.1), radius: 4, x: 1, y: 2)
                             .frame(maxWidth: .infinity)
                             .frame(height: 58)

--- a/Project_Timer/Setting/Service/SettingTiTiLab/TestServer/SignupLoginVC.swift
+++ b/Project_Timer/Setting/Service/SettingTiTiLab/TestServer/SignupLoginVC.swift
@@ -182,6 +182,7 @@ extension SignupLoginVC {
     @objc func keyboardWillShow(_ notification: NSNotification) {
         if let keyboardRectangle = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect {
             // keyboard 높이에 따라 bounds.origin 값 조정
+            print(keyboardRectangle.height)
             let keyboardY = self.view.bounds.height - keyboardRectangle.height
             let textFieldOrigin = self.textFieldOrigin
             let targetY = textFieldOrigin.y + LoginInputTextfield.height + 16


### PR DESCRIPTION
### 개요
- Issue: #109 
- Tech Spec: [회원 관리 기능 개발](https://www.notion.so/timertiti/4cb5c74f656e4bf784cff130213fd086?pvs=4)
- Figma: [로그인 프로세스](https://www.figma.com/file/T8hsaAguFkPytBiNMOOw03/Develop?type=design&node-id=670-9559&mode=design)

---

### 변경사항
- [x] keyboard 표시 감지 및 keyboard 높이 감지용 KeyboardResponder 생성
- [x] keyboard 표시 및 제거시 Device type에 따른 offset 조정값을 계산하여 조정
- [x] SwiftUI 내 GeometryReader 를 통해 화면크기를 읽을시 safearea 문제를 해결하기 위한 Landscape 분기값 추가

<img src="https://github.com/TimerTiTi/TiTi_iOS/assets/65349445/dfadf179-d5c5-4248-9d64-89db20e05315">

---

### Keyboard 표시에 따른 화면이동
- SwiftUI 에서는 frame.origin 값을 통한 View의 현재위치를 파악하기가 어려웠다.
- 그리고 상단부터 채워져서 표시되는 스크롤바 형태의 UI가 아니였다.
- 따라서 고민 후 디바이스별 offset 조정값을 대응하는 식으로 개발하였다.
- 추후 TextField의 위치를 토대로 keyboard 높이값과 계산하여 offset를 조정하는 식으로 개선해볼 여지가 존재한다.
```swift
func keyboardOffset(_ keyboardShow: Bool) -> CGFloat {
    if keyboardShow == false || keyboard.keyboardHeight < 260 {
        return 0
    } else {
        switch superViewSize.deviceDetailType {
        case .iPhoneMini:
            return -100
        case .iPhonePro:
            return -84
        case .iPhoneMax:
            return -54
        case .iPadMini:
            switch UIDevice.current.orientation {
            case .landscapeLeft, .landscapeRight:
                return -225
            default:
                return 0
            }
        case .iPad11:
            switch UIDevice.current.orientation {
            case .landscapeLeft, .landscapeRight:
                return -180
            default:
                return 0
            }
        case .iPad12:
            switch UIDevice.current.orientation {
            case .landscapeLeft, .landscapeRight:
                return -155
            default:
                return 0
            }
        }
    }
}
```

### SwiftUI 내 현재 표시되는 화면크기
- SwiftUI 에서는GeometryReader 를 통해 상단뷰의 크기를 얻을 수 있었다.
- 하지만 navigationBar 또는 safeArea 영역이 제외된 크기였기에 디바이스 크기별 UI 조정에 어려움이 있었다.
- 따라서 iPhone의 경우는 기존 width 를 기준으로 하였고, iPad의 경우는 가로모드, 세로모드에 따라 정확한 width, height 값을 토대로 분기처리 하였다.
- 또한 기본적으로 Keyboard가 표시되면 컨텐츠가 위로 올라오거나, GeometryReader 의 높이가 줄어들었던 현상이 있었으며, 이는 최상단 뷰에 `.ignoresSafeArea(.keyboard)` modifier를 추가하여 해결하였다.
```swift
enum DeviceDetailType: CGFloat {
    case iPad12 = 1024
    case iPad11 = 834
    case iPadMini = 744
    case iPhoneMax = 430
    case iPhonePro = 390
    case iPhoneMini = 375
}

enum DeviceLandspace: CGFloat {
    case iPad12 = 1366
    case iPad11 = 1194
    case iPadMini = 1133
    case iPhoneMax = 932
    case iPhonePro = 844
    case iPhoneMini = 667
}

var deviceDetailType: DeviceDetailType {
    let min = minLength
    let max = max(self.width, self.height)
    
    // iPad
    if min > DeviceDetailType.iPhoneMax.rawValue {
        switch UIDevice.current.orientation {
        case .landscapeLeft, .landscapeRight:
            if max >= DeviceLandspace.iPad12.rawValue {
                return .iPad12
            } else if max >= DeviceLandspace.iPad11.rawValue {
                return .iPad11
            } else {
                return .iPadMini
            }
        default:
            if min >= DeviceDetailType.iPad12.rawValue {
                return .iPad12
            } else if min >= DeviceDetailType.iPad11.rawValue {
                return .iPad11
            } else {
                return .iPadMini
            }
        }
    }
    // iPhone
    else {
        if min >= 428 { // 428 ~ 430 이내만 iPhoneMax UI 표시
            return .iPhoneMax
        } else if min >= DeviceDetailType.iPhonePro.rawValue {
            return .iPhonePro
        } else {
            return .iPhoneMini
        }
    }
}
```

### keyboardWillShowNotification 버그
- SwiftUI 내 TextField 에서 Simulator를 통해 하드웨어 키보드를 사용하거나, iPad 에서 블루투스를 통한 키보드를 사용시에도 keyboard가 표시된다고, keyboard의 높이값이 있다고 반환해주는 버그가 존재하였다.
- UIKit 에서는 동일한 keyboardWillShowNotification 수신이여도 해당 경우들은 수신되지 않았기에 SwiftUI의 버그로 보였다.
- 따라서 이를 해결하고자 keyboard의 높이값이 iPhoneSE의 높이값보다 낮은 경우로 추가적인 분기처리를 통해 해결할 수 있었다.
```swift
func keyboardOffset(_ keyboardShow: Bool) -> CGFloat {
    if keyboardShow == false || keyboard.keyboardHeight < 260 {
        return 0
    } else {
        ...
    }
}
```

### Reference
- [Move TextField up when the keyboard has appeared in SwiftUI](https://stackoverflow.com/questions/56491881/move-textfield-up-when-the-keyboard-has-appeared-in-swiftui)
- [SwiftUI TextField cursor colour](https://stackoverflow.com/questions/58469096/swiftui-textfield-cursor-colour)