### PR TITLE
비밀번호 입력화면 개발 & SwiftUI용 앵프라맹스 구현 내용

### DIFF
--- a/Project_Timer.xcodeproj/project.pbxproj
+++ b/Project_Timer.xcodeproj/project.pbxproj
@@ -231,6 +231,9 @@
 		87A7624726493BB500174401 /* LogHomeVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87A7624626493BB500174401 /* LogHomeVC.swift */; };
 		87A7F5D4267270F800F69EBA /* Todo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87A7F5D3267270F800F69EBA /* Todo.swift */; };
 		87A8BC3B288D1436007ED793 /* LogVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87A8BC3A288D1436007ED793 /* LogVC.swift */; };
+		87A8CD252AF0C37200D4C1D7 /* SignupSecureFieldView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87A8CD242AF0C37200D4C1D7 /* SignupSecureFieldView.swift */; };
+		87A8CD272AF0C4B600D4C1D7 /* OverlayShowButtonForSecureFieldView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87A8CD262AF0C4B600D4C1D7 /* OverlayShowButtonForSecureFieldView.swift */; };
+		87A8CD292AF0C5CB00D4C1D7 /* OverlayRemoveButtonForTextFieldView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87A8CD282AF0C5CB00D4C1D7 /* OverlayRemoveButtonForTextFieldView.swift */; };
 		87AE748429062ACA00FA0A60 /* TimeSelectorPopupVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87AE748329062ACA00FA0A60 /* TimeSelectorPopupVC.swift */; };
 		87AEF671289D23400018FCC8 /* UITabBarController+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87AEF670289D23400018FCC8 /* UITabBarController+Extension.swift */; };
 		87B539AB299BB710001E354C /* Versions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87B539AA299BB710001E354C /* Versions.swift */; };
@@ -542,6 +545,9 @@
 		87A7624626493BB500174401 /* LogHomeVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogHomeVC.swift; sourceTree = "<group>"; };
 		87A7F5D3267270F800F69EBA /* Todo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Todo.swift; sourceTree = "<group>"; };
 		87A8BC3A288D1436007ED793 /* LogVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogVC.swift; sourceTree = "<group>"; };
+		87A8CD242AF0C37200D4C1D7 /* SignupSecureFieldView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignupSecureFieldView.swift; sourceTree = "<group>"; };
+		87A8CD262AF0C4B600D4C1D7 /* OverlayShowButtonForSecureFieldView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OverlayShowButtonForSecureFieldView.swift; sourceTree = "<group>"; };
+		87A8CD282AF0C5CB00D4C1D7 /* OverlayRemoveButtonForTextFieldView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OverlayRemoveButtonForTextFieldView.swift; sourceTree = "<group>"; };
 		87AE748329062ACA00FA0A60 /* TimeSelectorPopupVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeSelectorPopupVC.swift; sourceTree = "<group>"; };
 		87AEF670289D23400018FCC8 /* UITabBarController+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITabBarController+Extension.swift"; sourceTree = "<group>"; };
 		87B539AA299BB710001E354C /* Versions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Versions.swift; sourceTree = "<group>"; };
@@ -1086,6 +1092,7 @@
 			children = (
 				8706C32B2AEF864000F7C842 /* SignupTitleView.swift */,
 				87E5C70E2AE0C0E500BE46B0 /* SignupTextFieldView.swift */,
+				87A8CD242AF0C37200D4C1D7 /* SignupSecureFieldView.swift */,
 				8706C32D2AEF878D00F7C842 /* SignupTextFieldUnderlineView.swift */,
 				8706C32F2AEF881500F7C842 /* SignupTextFieldWarning.swift */,
 				8706C3312AEF8A0300F7C842 /* SignupNextButtonForMac.swift */,
@@ -1106,6 +1113,8 @@
 			isa = PBXGroup;
 			children = (
 				878DA1FC2AEF7CEF00C60CBF /* ConfigureForTextFieldRootView.swift */,
+				87A8CD282AF0C5CB00D4C1D7 /* OverlayRemoveButtonForTextFieldView.swift */,
+				87A8CD262AF0C4B600D4C1D7 /* OverlayShowButtonForSecureFieldView.swift */,
 			);
 			path = Modifier;
 			sourceTree = "<group>";
@@ -1899,6 +1908,7 @@
 				87BE88E72AD425BE0010A84A /* LoginTextFieldView.swift in Sources */,
 				87E5C70D2AE0268C00BE46B0 /* SignupEmailView.swift in Sources */,
 				049BBA9A28AB5747005BAB1B /* TaskModifyInteractionView.swift in Sources */,
+				87A8CD272AF0C4B600D4C1D7 /* OverlayShowButtonForSecureFieldView.swift in Sources */,
 				870E85012AD67E46000511BD /* KeyboardResponder.swift in Sources */,
 				87A48BCB27DF112B00F46D0F /* LogHomeVM.swift in Sources */,
 				87D7ED172952B69200121DE6 /* TestUserLoginInfo.swift in Sources */,
@@ -1907,6 +1917,7 @@
 				87F10930284C4337002E31EA /* TiTiLabHeaderView.swift in Sources */,
 				879D20812A19E44B00D8A420 /* TargetTimeView.swift in Sources */,
 				87A4704826493D4D007B89D6 /* RecordTimes.swift in Sources */,
+				87A8CD252AF0C37200D4C1D7 /* SignupSecureFieldView.swift in Sources */,
 				872C0EE3284AF26A00E8E3F2 /* SettingUpdateHistoryVM.swift in Sources */,
 				87EFD6832AC12C3800C422B1 /* LoginSignupEnvironment.swift in Sources */,
 				93A892B124C14D4700F89180 /* CircularProgressView.swift in Sources */,
@@ -1920,6 +1931,7 @@
 				873C197828D044CC00E02ADC /* DailyVM.swift in Sources */,
 				879108252838761B005D7B10 /* NetworkStatus.swift in Sources */,
 				87BF666C28F80EA500CD6F19 /* NormalTimeLabelVM.swift in Sources */,
+				87A8CD292AF0C5CB00D4C1D7 /* OverlayRemoveButtonForTextFieldView.swift in Sources */,
 				8751C6F628472133007FAFC4 /* SettingCellInfo.swift in Sources */,
 				8750082D2905998200E27B4A /* TargetTimeSettingPopupVC.swift in Sources */,
 				8760FCB929541BE3000BCCD1 /* KeyChain.swift in Sources */,

--- a/Project_Timer.xcodeproj/project.pbxproj
+++ b/Project_Timer.xcodeproj/project.pbxproj
@@ -57,6 +57,9 @@
 		870E117B2A0F7DEE00CFA77C /* CalendarWidgetCellData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 870E117A2A0F7DEE00CFA77C /* CalendarWidgetCellData.swift */; };
 		870E117C2A0F7EF000CFA77C /* CalendarWidgetCellData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 870E117A2A0F7DEE00CFA77C /* CalendarWidgetCellData.swift */; };
 		870E85012AD67E46000511BD /* KeyboardResponder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 870E85002AD67E46000511BD /* KeyboardResponder.swift */; };
+		870F90E32AEFF7FC00854DDB /* SignupPasswordView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 870F90E22AEFF7FC00854DDB /* SignupPasswordView.swift */; };
+		870F90E52AEFFA9300854DDB /* SignupPasswordModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 870F90E42AEFFA9300854DDB /* SignupPasswordModel.swift */; };
+		870F90E72AEFFF1A00854DDB /* SignupPasswordRoute.swift in Sources */ = {isa = PBXBuildFile; fileRef = 870F90E62AEFFF1A00854DDB /* SignupPasswordRoute.swift */; };
 		87163DC82ACAF2E8008D4072 /* NetworkError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87163DC72ACAF2E8008D4072 /* NetworkError.swift */; };
 		87163DCA2ACAF89B008D4072 /* NetworkResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87163DC92ACAF89B008D4072 /* NetworkResult.swift */; };
 		87168D99299A819F003ED502 /* UserDefaults+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 875C98C82871BFCF008F7ADD /* UserDefaults+Extension.swift */; };
@@ -368,6 +371,9 @@
 		870E11742A0E226D00CFA77C /* CalendarWidgetData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarWidgetData.swift; sourceTree = "<group>"; };
 		870E117A2A0F7DEE00CFA77C /* CalendarWidgetCellData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarWidgetCellData.swift; sourceTree = "<group>"; };
 		870E85002AD67E46000511BD /* KeyboardResponder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardResponder.swift; sourceTree = "<group>"; };
+		870F90E22AEFF7FC00854DDB /* SignupPasswordView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignupPasswordView.swift; sourceTree = "<group>"; };
+		870F90E42AEFFA9300854DDB /* SignupPasswordModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignupPasswordModel.swift; sourceTree = "<group>"; };
+		870F90E62AEFFF1A00854DDB /* SignupPasswordRoute.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignupPasswordRoute.swift; sourceTree = "<group>"; };
 		87163DC72ACAF2E8008D4072 /* NetworkError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkError.swift; sourceTree = "<group>"; };
 		87163DC92ACAF89B008D4072 /* NetworkResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkResult.swift; sourceTree = "<group>"; };
 		87199F432882BC430017D01A /* StandardDailyGraphView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StandardDailyGraphView.swift; sourceTree = "<group>"; };
@@ -708,6 +714,16 @@
 				87DA71722A124261006294DE /* MonthWidgetData+Snapshot.swift */,
 			);
 			path = Data;
+			sourceTree = "<group>";
+		};
+		870F90E12AEFF7DE00854DDB /* Password */ = {
+			isa = PBXGroup;
+			children = (
+				870F90E62AEFFF1A00854DDB /* SignupPasswordRoute.swift */,
+				870F90E22AEFF7FC00854DDB /* SignupPasswordView.swift */,
+				870F90E42AEFFA9300854DDB /* SignupPasswordModel.swift */,
+			);
+			path = Password;
 			sourceTree = "<group>";
 		};
 		87199F422882BC0C0017D01A /* Graph */ = {
@@ -1479,6 +1495,7 @@
 			isa = PBXGroup;
 			children = (
 				878DA1F32AEE610F00C60CBF /* Email */,
+				870F90E12AEFF7DE00854DDB /* Password */,
 			);
 			path = Signup;
 			sourceTree = "<group>";
@@ -1841,6 +1858,7 @@
 				048D8AC628AA1B7700A2456D /* AddHistoryCell.swift in Sources */,
 				870474F628F148C700CC03A8 /* SettingColorVC.swift in Sources */,
 				8760FB092A1DAFA70068CEF5 /* SettingCalendarWidgetVC.swift in Sources */,
+				870F90E72AEFFF1A00854DDB /* SignupPasswordRoute.swift in Sources */,
 				8765234628C76B6D00487BFB /* WeekSmallTime.swift in Sources */,
 				875C98C1287175F7008F7ADD /* TiTiLabActionDelegate.swift in Sources */,
 				878DA1F62AEE617900C60CBF /* SignupInfo.swift in Sources */,
@@ -1856,8 +1874,10 @@
 				87DB923E2AC2D06C00FE6453 /* View+Extension.swift in Sources */,
 				043706272869D58C00A5D3AA /* TimerTimeLabelView.swift in Sources */,
 				874F9C312ABFF81300675A86 /* EmailLoginButton.swift in Sources */,
+				870F90E52AEFFA9300854DDB /* SignupPasswordModel.swift in Sources */,
 				878899822894F05F00B7F378 /* StandardWeekTaskCell.swift in Sources */,
 				877911B82A18903000F0A713 /* SettingListCell.swift in Sources */,
+				870F90E32AEFF7FC00854DDB /* SignupPasswordView.swift in Sources */,
 				87BEBEEB281C19CA0095CD29 /* StopwatchVM.swift in Sources */,
 				87BFCBCC28EFB10F00FC688E /* TargetTimePickerVM.swift in Sources */,
 				87F1093A284C589A002E31EA /* FunctionInfo.swift in Sources */,

--- a/Project_Timer.xcodeproj/project.pbxproj
+++ b/Project_Timer.xcodeproj/project.pbxproj
@@ -2188,7 +2188,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = Project_Timer/Project_Timer.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 3;
+				CURRENT_PROJECT_VERSION = 4;
 				DEVELOPMENT_TEAM = 2C96RNDN63;
 				"ENABLE_HARDENED_RUNTIME[sdk=macosx*]" = YES;
 				INFOPLIST_FILE = Project_Timer/Info.plist;
@@ -2427,7 +2427,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = Project_Timer/Project_Timer.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 3;
+				CURRENT_PROJECT_VERSION = 4;
 				DEVELOPMENT_TEAM = 2C96RNDN63;
 				"ENABLE_HARDENED_RUNTIME[sdk=macosx*]" = YES;
 				INFOPLIST_FILE = Project_Timer/Info.plist;
@@ -2454,7 +2454,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = Project_Timer/Project_Timer.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 3;
+				CURRENT_PROJECT_VERSION = 4;
 				DEVELOPMENT_TEAM = 2C96RNDN63;
 				"ENABLE_HARDENED_RUNTIME[sdk=macosx*]" = YES;
 				INFOPLIST_FILE = Project_Timer/Info.plist;

--- a/Project_Timer/AppDelegate.swift
+++ b/Project_Timer/AppDelegate.swift
@@ -22,14 +22,17 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var shouldSupportPortraitOrientation = false
     
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        /// 애드몹 이니셜라이즈
-        GADMobileAds.sharedInstance().start(completionHandler: nil)
+        if Infos.isDevMode == false {
+            /// 애드몹 이니셜라이즈
+            GADMobileAds.sharedInstance().start(completionHandler: nil)
+            
+            /// 앱 실행시 Analytics 에 정보 전달부분
+            FirebaseApp.configure()
+            Analytics.logEvent("launch", parameters: [
+                AnalyticsParameterItemID: "ver \(String.currentVersion)",
+            ])
+        }
         
-        /// 앱 실행시 Analytics 에 정보 전달부분
-        FirebaseApp.configure()
-        Analytics.logEvent("launch", parameters: [
-            AnalyticsParameterItemID: "ver \(String.currentVersion)",
-        ])
         /// Foreground 에서 알림설정을 활성화 하기 위한 delegate 연결 부분
         UNUserNotificationCenter.current().delegate = self
         NotificationCenter.default.addObserver(forName: .setBadge, object: nil, queue: .current) { _ in

--- a/Project_Timer/Global/Extension/SwiftUI/View+Extension.swift
+++ b/Project_Timer/Global/Extension/SwiftUI/View+Extension.swift
@@ -49,3 +49,13 @@ extension View {
         }
     }
 }
+
+// MARK: Functions
+extension View {
+    func scroll(_ scrollViewProxy: ScrollViewProxy, to: any Hashable) {
+        #if targetEnvironment(macCatalyst)
+        #else
+        scrollViewProxy.scrollTo(to, anchor: .bottom)
+        #endif
+    }
+}

--- a/Project_Timer/Global/SingletonClass/KeyboardResponder.swift
+++ b/Project_Timer/Global/SingletonClass/KeyboardResponder.swift
@@ -9,13 +9,16 @@
 import SwiftUI
 
 final class KeyboardResponder: ObservableObject {
+    static let shared = KeyboardResponder()
+    
     private var notificationCenter: NotificationCenter
     @Published private(set) var keyboardHeight: CGFloat = 0
     @Published private(set) var keyboardShow: Bool = false
     @Published private(set) var keyboardHide: Bool = false
 
-    init() {
+    private init() {
         notificationCenter = .default
+        addObserver()
     }
     
     func addObserver() {
@@ -28,7 +31,7 @@ final class KeyboardResponder: ObservableObject {
     }
 
     deinit {
-        notificationCenter.removeObserver(self)
+        removeObserver()
     }
 
     @objc func keyBoardWillShow(notification: Notification) {

--- a/Project_Timer/LoginSignup/Presentation/Common/Modifier/OverlayRemoveButtonForTextFieldView.swift
+++ b/Project_Timer/LoginSignup/Presentation/Common/Modifier/OverlayRemoveButtonForTextFieldView.swift
@@ -1,0 +1,38 @@
+//
+//  OverlayRemoveButtonForTextFieldView.swift
+//  Project_Timer
+//
+//  Created by Kang Minsang on 2023/10/31.
+//  Copyright © 2023 FDEE. All rights reserved.
+//
+
+import Foundation
+import SwiftUI
+
+struct OverlayRemoveButtonForTextFieldView: ViewModifier {
+    var isVisible: Bool
+    var action: () -> Void
+    
+    func body(content: Content) -> some View {
+        content
+            .overlay {
+                if isVisible {
+                    HStack {
+                        Spacer()
+                        Button {
+                            action()
+                        } label: {
+                            Image(systemName: "multiply.circle.fill")
+                        }
+                        .foregroundColor(.secondary)
+                    }
+                }
+            }
+    }
+}
+
+extension View {
+    func overlayRemoveButtonForTextFieldView(isVisible: Bool, action: @escaping () -> Void) -> some View {
+        modifier(OverlayRemoveButtonForTextFieldView(isVisible: isVisible, action: action))
+    }
+}

--- a/Project_Timer/LoginSignup/Presentation/Common/Modifier/OverlayShowButtonForSecureFieldView.swift
+++ b/Project_Timer/LoginSignup/Presentation/Common/Modifier/OverlayShowButtonForSecureFieldView.swift
@@ -1,0 +1,40 @@
+//
+//  OverlayShowButtonForSecureFieldView.swift
+//  Project_Timer
+//
+//  Created by Kang Minsang on 2023/10/31.
+//  Copyright © 2023 FDEE. All rights reserved.
+//
+
+import Foundation
+import SwiftUI
+
+struct OverlayShowButtonForSecureFieldView: ViewModifier {
+    var isVisible: Bool
+    var isSecure: Bool
+    var action: () -> Void
+    
+    func body(content: Content) -> some View {
+        content
+            .overlay {
+                if isVisible {
+                    HStack {
+                        Spacer()
+                        Button {
+                            action()
+                        } label: {
+                            Image(systemName: isSecure ? "eye.slash" : "eye")
+                        }
+                        .foregroundColor(.secondary)
+                    }
+                }
+                
+            }
+    }
+}
+
+extension View {
+    func overlayShowButtonForSecureFieldView(isVisible: Bool, isSecure: Bool, action: @escaping () -> Void) -> some View {
+        modifier(OverlayShowButtonForSecureFieldView(isVisible: isVisible, isSecure: isSecure, action: action))
+    }
+}

--- a/Project_Timer/LoginSignup/Presentation/Common/View/SignupSecureFieldView.swift
+++ b/Project_Timer/LoginSignup/Presentation/Common/View/SignupSecureFieldView.swift
@@ -18,26 +18,56 @@ struct SignupSecureFieldView: View {
     @State private var isSecure: Bool = true
     
     var body: some View {
-        SecureField("", text: $text)
-            .font(TiTiFont.HGGGothicssiP60g(size: 20))
-            .foregroundStyle(.primary)
-            .accentColor(.blue)
-            .autocorrectionDisabled(true)
-            .placeholder(when: text.isEmpty) { // placeholder 텍스트 설정
-                Text(placeholder)
-                    .font(TiTiFont.HGGGothicssiP60g(size: 20))
-                    .foregroundStyle(UIColor.placeholderText.toColor)
+        ZStack {
+            TextField("", text: $text)
+                .font(TiTiFont.HGGGothicssiP60g(size: 20))
+                .foregroundStyle(.primary)
+                .accentColor(.blue)
+                .autocorrectionDisabled(true)
+                .placeholder(when: text.isEmpty) { // placeholder 텍스트 설정
+                    Text(placeholder)
+                        .font(TiTiFont.HGGGothicssiP60g(size: 20))
+                        .foregroundStyle(UIColor.placeholderText.toColor)
+                }
+                .keyboardType(keyboardType)
+                .focused($focus, equals: self.type) // textField 활성화값 반영
+                .submitLabel(.done) // 키보드 done 버튼 활성화
+                .onSubmit { // 키보드 done 버튼 액션
+                    submitAction()
+                }
+                .frame(height: 22)
+                .overlayShowButtonForSecureFieldView(isVisible: (focus == self.type && !text.isEmpty), isSecure: isSecure, action: {
+                    isSecure.toggle()
+                })
+                .opacity(isSecure ? 0 : 1)
+            
+            SecureField("", text: $text)
+                .font(TiTiFont.HGGGothicssiP60g(size: 20))
+                .foregroundStyle(.primary)
+                .accentColor(.blue)
+                .autocorrectionDisabled(true)
+                .placeholder(when: text.isEmpty) { // placeholder 텍스트 설정
+                    Text(placeholder)
+                        .font(TiTiFont.HGGGothicssiP60g(size: 20))
+                        .foregroundStyle(UIColor.placeholderText.toColor)
+                }
+                .keyboardType(keyboardType)
+                .focused($focus, equals: self.type) // textField 활성화값 반영
+                .submitLabel(.done) // 키보드 done 버튼 활성화
+                .onSubmit { // 키보드 done 버튼 액션
+                    submitAction()
+                }
+                .frame(height: 22)
+                .overlayShowButtonForSecureFieldView(isVisible: (focus == self.type && !text.isEmpty), isSecure: isSecure, action: {
+                    isSecure.toggle()
+                })
+                .opacity(isSecure ? 1 : 0)
+        }
+        .onChange(of: focus) { newValue in
+            if newValue == nil {
+                isSecure = true
             }
-            .keyboardType(keyboardType)
-            .focused($focus, equals: self.type) // textField 활성화값 반영
-            .submitLabel(.done) // 키보드 done 버튼 활성화
-            .onSubmit { // 키보드 done 버튼 액션
-                submitAction()
-            }
-            .frame(height: 22)
-            .overlayShowButtonForSecureFieldView(isVisible: (focus == self.type && !text.isEmpty), isSecure: isSecure, action: {
-                isSecure.toggle()
-            })
+        }
     }
     
     var placeholder: String {

--- a/Project_Timer/LoginSignup/Presentation/Common/View/SignupSecureFieldView.swift
+++ b/Project_Timer/LoginSignup/Presentation/Common/View/SignupSecureFieldView.swift
@@ -1,30 +1,24 @@
 //
-//  LoginTextFieldView.swift
+//  SignupSecureFieldView.swift
 //  Project_Timer
 //
-//  Created by Kang Minsang on 2023/10/09.
+//  Created by Kang Minsang on 2023/10/31.
 //  Copyright © 2023 FDEE. All rights reserved.
 //
 
 import SwiftUI
 
-struct SignupTextFieldView: View {
-    enum type: Equatable {
-        case email
-        case authCode
-        case password
-        case password2
-        case nickname
-    }
-    
-    let type: type
+struct SignupSecureFieldView: View {
+    let type: SignupTextFieldView.type
     let keyboardType: UIKeyboardType
     @Binding var text: String
-    @FocusState.Binding var focus: type?
+    @FocusState.Binding var focus: SignupTextFieldView.type?
     let submitAction: () -> Void
     
+    @State private var isSecure: Bool = true
+    
     var body: some View {
-        TextField("", text: $text)
+        SecureField("", text: $text)
             .font(TiTiFont.HGGGothicssiP60g(size: 20))
             .foregroundStyle(.primary)
             .accentColor(.blue)
@@ -41,31 +35,29 @@ struct SignupTextFieldView: View {
                 submitAction()
             }
             .frame(height: 22)
-            .overlayRemoveButtonForTextFieldView(isVisible: (focus == self.type && !text.isEmpty), action: {
-                text = ""
+            .overlayShowButtonForSecureFieldView(isVisible: (focus == self.type && !text.isEmpty), isSecure: isSecure, action: {
+                isSecure.toggle()
             })
     }
     
     var placeholder: String {
         switch self.type {
-        case .email:
-            return "email".localized()
-        case .authCode:
-            return "verification code".localized()
-        case .nickname:
-            return "nickname".localized()
+        case .password:
+            return "new password".localized()
+        case .password2:
+            return "confirm new password".localized()
         default:
             return "placeholder"
         }
     }
 }
 
-struct SignupFieldView_Previews: PreviewProvider {
+struct SignupSecureFieldView_Previews: PreviewProvider {
     @State static private var text: String = ""
     @FocusState static private var focus: SignupTextFieldView.type?
     
     static var previews: some View {
-        SignupTextFieldView(type: .email, keyboardType: .emailAddress, text: $text, focus: $focus) {
+        SignupSecureFieldView(type: .password, keyboardType: .alphabet, text: $text, focus: $focus) {
             print("submit")
         }
     }

--- a/Project_Timer/LoginSignup/Presentation/Common/View/SignupTextFieldUnderlineView.swift
+++ b/Project_Timer/LoginSignup/Presentation/Common/View/SignupTextFieldUnderlineView.swift
@@ -13,7 +13,7 @@ struct SignupTextFieldUnderlineView: View {
     var color: Color
     
     var body: some View {
-        VStack(spacing: 0) {
+        VStack(alignment: .leading, spacing: 0) {
             Spacer()
                 .frame(height: 12)
             

--- a/Project_Timer/LoginSignup/Presentation/Common/View/SignupTextFieldView.swift
+++ b/Project_Timer/LoginSignup/Presentation/Common/View/SignupTextFieldView.swift
@@ -11,7 +11,7 @@ import SwiftUI
 struct SignupTextFieldView: View {
     enum type: Equatable {
         case email
-        case authCode
+        case verificationCode
         case password
         case password2
         case nickname
@@ -50,7 +50,7 @@ struct SignupTextFieldView: View {
         switch self.type {
         case .email:
             return "email".localized()
-        case .authCode:
+        case .verificationCode:
             return "verification code".localized()
         case .nickname:
             return "nickname".localized()

--- a/Project_Timer/LoginSignup/Presentation/Common/View/SignupTextFieldView.swift
+++ b/Project_Timer/LoginSignup/Presentation/Common/View/SignupTextFieldView.swift
@@ -23,8 +23,9 @@ struct SignupTextFieldView: View {
     let submitAction: () -> Void
     
     var body: some View {
-        if self.type != .password {
-            TextField("", text: $text)
+        if self.type == .password || self.type == .password2 {
+            
+            SecureField("", text: $text)
                 .font(TiTiFont.HGGGothicssiP60g(size: 20))
                 .foregroundStyle(.primary)
                 .accentColor(.blue)
@@ -55,7 +56,7 @@ struct SignupTextFieldView: View {
                     }
                 }
         } else {
-            SecureField("", text: $text)
+            TextField("", text: $text)
                 .font(TiTiFont.HGGGothicssiP60g(size: 20))
                 .foregroundStyle(.primary)
                 .accentColor(.blue)
@@ -97,7 +98,7 @@ struct SignupTextFieldView: View {
         case .password:
             return "new password".localized()
         case .password2:
-            return "retype password".localized()
+            return "confirm new password".localized()
         case .nickname:
             return "nickname".localized()
         }

--- a/Project_Timer/LoginSignup/Presentation/Common/View/SignupTextFieldWarning.swift
+++ b/Project_Timer/LoginSignup/Presentation/Common/View/SignupTextFieldWarning.swift
@@ -19,7 +19,7 @@ struct SignupTextFieldWarning: View {
     }
     
     var body: some View {
-        VStack(spacing: 0) {
+        VStack(alignment: .leading, spacing: 0) {
             Spacer()
                 .frame(height: 2)
             

--- a/Project_Timer/LoginSignup/Presentation/Common/View/SignupTextFieldWarning.swift
+++ b/Project_Timer/LoginSignup/Presentation/Common/View/SignupTextFieldWarning.swift
@@ -28,5 +28,6 @@ struct SignupTextFieldWarning: View {
                 .foregroundStyle(TiTiColor.wrongTextField.toColor)
                 .opacity(visible ? 1.0 : 0)
         }
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 }

--- a/Project_Timer/LoginSignup/Presentation/Login/LoginView/LoginView.swift
+++ b/Project_Timer/LoginSignup/Presentation/Login/LoginView/LoginView.swift
@@ -44,7 +44,7 @@ struct LoginView: View {
                 case .findPassword:
                     Text("findPassword")
                 case .signup:
-                    SignupEmailView(model: SignupEmailModel(type: .vender, venderInfo: nil))
+                    SignupEmailView(model: SignupEmailModel(infos: (type: .normal, venderInfo: nil)))
                 }
             }
         }

--- a/Project_Timer/LoginSignup/Presentation/Login/LoginView/LoginView.swift
+++ b/Project_Timer/LoginSignup/Presentation/Login/LoginView/LoginView.swift
@@ -9,7 +9,7 @@
 import SwiftUI
 
 struct LoginView: View {
-    @ObservedObject private var keyboard = KeyboardResponder()
+    @ObservedObject private var keyboard = KeyboardResponder.shared
     @State private var superViewSize: CGSize = .zero
     
     var body: some View {
@@ -27,12 +27,6 @@ struct LoginView: View {
                 }
                 .offset(y: keyboardOffset(keyboard.keyboardShow))
                 .animation(.easeIn(duration: keyboard.keyboardShow || keyboard.keyboardHide ? 0.2 : 0))
-            }
-            .onAppear {
-                keyboard.addObserver()
-            }
-            .onDisappear {
-                keyboard.removeObserver()
             }
             .onChange(of: geometry.size, perform: { value in
                 self.superViewSize = value

--- a/Project_Timer/LoginSignup/Presentation/Signup/Email/SignupEmailModel.swift
+++ b/Project_Timer/LoginSignup/Presentation/Signup/Email/SignupEmailModel.swift
@@ -10,10 +10,11 @@ import Foundation
 import Combine
 import SwiftUI
 
+typealias SignupSelectInfos = (type: SignupInfo.type, venderInfo: SignupVenderInfo?)
+
 // MARK: State
 class SignupEmailModel: ObservableObject {
-    let type: SignupInfo.type
-    let venderInfo: SignupVenderInfo?
+    let infos: SignupSelectInfos
     @Published var contentWidth: CGFloat = .zero
     @Published var focus: SignupTextFieldView.type?
     @Published var authCode: String = ""
@@ -24,11 +25,10 @@ class SignupEmailModel: ObservableObject {
     @Published var email: String = ""
     private var verificationKey = ""
     
-    init(type: SignupInfo.type, venderInfo: SignupVenderInfo?) {
-        self.type = type
-        self.venderInfo = venderInfo
+    init(infos: SignupSelectInfos) {
+        self.infos = infos
         
-        if let email = venderInfo?.email {
+        if let email = infos.venderInfo?.email {
             self.email = email
         }
     }
@@ -79,13 +79,13 @@ extension SignupEmailModel {
     }
     
     // 이메일 done 액션
-    func emailCheck() {
+    func checkEmail() {
         let emailValid = PredicateChecker.isValidEmail(email)
         wrongEmail = !emailValid
     }
     
     // 인증코드 done 액션
-    func authCodeCheck() {
+    func checkAuthCode() {
         let authCodeValid = authCode.count > 7
         wrongAuthCode = !authCodeValid
         

--- a/Project_Timer/LoginSignup/Presentation/Signup/Email/SignupEmailView.swift
+++ b/Project_Timer/LoginSignup/Presentation/Signup/Email/SignupEmailView.swift
@@ -37,12 +37,9 @@ struct SignupEmailView: View {
             .navigationDestination(for: SignupEmailRoute.self) { destination in
                 switch destination {
                 case .signupPassword:
+                    let prevInfos = model.infos
                     let emailInfo = model.emailInfo
-                    VStack {
-                        Text("Signup Password")
-                        Text(emailInfo.email)
-                        Text(emailInfo.verificationKey)
-                    }
+                    SignupPasswordView(model: SignupPasswordModel(infos: (prevInfos: prevInfos, emailInfo: emailInfo)))
                 }
             }
         }
@@ -62,8 +59,8 @@ struct SignupEmailView: View {
                             SignupTitleView(title: "Enter your email address", subTitle: "Please enter your email address for verification")
                             
                             SignupTextFieldView(type: .email, text: $model.email, focus: $focus) {
-                                model.emailCheck()
-                                focusCheckAfterEmail()
+                                model.checkEmail()
+                                checkFocusAfterEmail()
                             }
                             .id(SignupTextFieldView.type.email)
                             .onChange(of: model.email) { newValue in
@@ -74,7 +71,7 @@ struct SignupEmailView: View {
                             SignupTextFieldWarning(warning: "The format is incorrect. Please enter in the correct format", visible: model.wrongEmail == true)
                             
                             if model.wrongEmail == false {
-                                NextContentView(model: model, focus: $focus, focusCheckAfterAuthCode: focusCheckAfterAuthCode)
+                                NextContentView(model: model, focus: $focus, focusCheckAfterAuthCode: checkFocusAfterAuthCode)
                             }
                         }
                         .onAppear {
@@ -105,11 +102,11 @@ struct SignupEmailView: View {
                     SignupNextButtonForMac(visible: focus != nil) {
                         switch focus {
                         case .email:
-                            model.emailCheck()
-                            focusCheckAfterEmail()
+                            model.checkEmail()
+                            checkFocusAfterEmail()
                         case .authCode:
-                            model.authCodeCheck()
-                            focusCheckAfterAuthCode()
+                            model.checkAuthCode()
+                            checkFocusAfterAuthCode()
                         default:
                             return
                         }
@@ -123,13 +120,13 @@ struct SignupEmailView: View {
             .frame(width: model.contentWidth, alignment: .leading)
         }
         
-        func focusCheckAfterEmail() {
+        func checkFocusAfterEmail() {
             if model.wrongEmail == true {
                 focus = .email
             } 
         }
         
-        func focusCheckAfterAuthCode() {
+        func checkFocusAfterAuthCode() {
             if model.wrongAuthCode == true {
                 focus = .authCode
             }
@@ -148,7 +145,7 @@ struct SignupEmailView: View {
                 
                 HStack(alignment: .center, spacing: 16) {
                     SignupTextFieldView(type: .authCode, text: $model.authCode, focus: $focus) {
-                        model.authCodeCheck()
+                        model.checkAuthCode()
                         focusCheckAfterAuthCode()
                     }
                     .id(SignupTextFieldView.type.authCode)
@@ -185,9 +182,9 @@ struct SignupEmailView: View {
 
 struct SignupEmailView_Previews: PreviewProvider {
     static var previews: some View {
-        SignupEmailView(model: SignupEmailModel(type: .normal, venderInfo: nil)).environmentObject(LoginSignupEnvironment())
+        SignupEmailView(model: SignupEmailModel(infos: (type: .normal, venderInfo: nil))).environmentObject(LoginSignupEnvironment())
         
-        SignupEmailView(model: SignupEmailModel(type: .normal, venderInfo: nil)).environmentObject(LoginSignupEnvironment())
+        SignupEmailView(model: SignupEmailModel(infos: (type: .normal, venderInfo: nil))).environmentObject(LoginSignupEnvironment())
             .environment(\.locale, .init(identifier: "en"))
     }
 }

--- a/Project_Timer/LoginSignup/Presentation/Signup/Email/SignupEmailView.swift
+++ b/Project_Timer/LoginSignup/Presentation/Signup/Email/SignupEmailView.swift
@@ -58,7 +58,7 @@ struct SignupEmailView: View {
                         VStack(alignment: .leading, spacing: 0) {
                             SignupTitleView(title: "Enter your email address", subTitle: "Please enter your email address for verification")
                             
-                            SignupTextFieldView(type: .email, text: $model.email, focus: $focus) {
+                            SignupTextFieldView(type: .email, keyboardType: .emailAddress, text: $model.email, focus: $focus) {
                                 model.checkEmail()
                                 checkFocusAfterEmail()
                             }
@@ -66,7 +66,6 @@ struct SignupEmailView: View {
                             .onChange(of: model.email) { newValue in
                                 model.wrongEmail = nil
                             }
-                            
                             SignupTextFieldUnderlineView(color: model.emailTintColor)
                             SignupTextFieldWarning(warning: "The format is incorrect. Please enter in the correct format", visible: model.wrongEmail == true)
                             
@@ -144,7 +143,7 @@ struct SignupEmailView: View {
                     .frame(height: 35)
                 
                 HStack(alignment: .center, spacing: 16) {
-                    SignupTextFieldView(type: .authCode, text: $model.authCode, focus: $focus) {
+                    SignupTextFieldView(type: .authCode, keyboardType: .alphabet, text: $model.authCode, focus: $focus) {
                         model.checkAuthCode()
                         focusCheckAfterAuthCode()
                     }

--- a/Project_Timer/LoginSignup/Presentation/Signup/Email/SignupEmailView.swift
+++ b/Project_Timer/LoginSignup/Presentation/Signup/Email/SignupEmailView.swift
@@ -9,7 +9,7 @@
 import SwiftUI
 
 struct SignupEmailView: View {
-    @ObservedObject private var keyboard = KeyboardResponder()
+    @ObservedObject private var keyboard = KeyboardResponder.shared
     @StateObject private var model: SignupEmailModel
     
     init(model: SignupEmailModel) {
@@ -23,12 +23,6 @@ struct SignupEmailView: View {
                     .ignoresSafeArea()
                 
                 ContentView(model: model)
-                    .onAppear {
-                        keyboard.addObserver()
-                    }
-                    .onDisappear {
-                        keyboard.removeObserver()
-                    }
                     .padding(.bottom, keyboard.keyboardHeight)
             }
             .onChange(of: geometry.size, perform: { value in
@@ -62,11 +56,11 @@ struct SignupEmailView: View {
                                 model.checkEmail()
                                 checkFocusAfterEmail()
                             }
-                            .id(SignupTextFieldView.type.email)
                             .onChange(of: model.email) { newValue in
                                 model.wrongEmail = nil
                             }
                             SignupTextFieldUnderlineView(color: model.emailTintColor)
+                                .id(SignupTextFieldView.type.email)
                             SignupTextFieldWarning(warning: "The format is incorrect. Please enter in the correct format", visible: model.wrongEmail == true)
                             
                             if model.wrongEmail == false {
@@ -147,7 +141,6 @@ struct SignupEmailView: View {
                         model.checkAuthCode()
                         focusCheckAfterAuthCode()
                     }
-                    .id(SignupTextFieldView.type.authCode)
                     .onChange(of: model.authCode) { newValue in
                         model.wrongAuthCode = nil
                     }
@@ -173,6 +166,7 @@ struct SignupEmailView: View {
                 }
                 
                 SignupTextFieldUnderlineView(color: model.authCodeTintColor)
+                    .id(SignupTextFieldView.type.authCode)
                 SignupTextFieldWarning(warning: "The verification code is not valid. Please try again", visible: model.wrongAuthCode == true)
             }
         }

--- a/Project_Timer/LoginSignup/Presentation/Signup/Password/SignupPasswordModel.swift
+++ b/Project_Timer/LoginSignup/Presentation/Signup/Password/SignupPasswordModel.swift
@@ -34,7 +34,7 @@ class SignupPasswordModel: ObservableObject {
     
     // passwordTextField underline 컬러
     var passwordTintColor: Color {
-        if validPassword == false {
+        if validPassword == false && password.isEmpty {
             return TiTiColor.wrongTextField.toColor
         } else {
             return focus == .password ? Color.blue : UIColor.placeholderText.toColor
@@ -42,7 +42,7 @@ class SignupPasswordModel: ObservableObject {
     }
     
     var password2TintColor: Color {
-        if validPassword2 == false {
+        if validPassword2 == false && password2.isEmpty {
             return TiTiColor.wrongTextField.toColor
         } else {
             return focus == .password2 ? Color.blue : UIColor.placeholderText.toColor

--- a/Project_Timer/LoginSignup/Presentation/Signup/Password/SignupPasswordModel.swift
+++ b/Project_Timer/LoginSignup/Presentation/Signup/Password/SignupPasswordModel.swift
@@ -41,6 +41,7 @@ class SignupPasswordModel: ObservableObject {
         }
     }
     
+    // passwordTextField2 underline 컬러
     var password2TintColor: Color {
         if validPassword2 == false && password2.isEmpty {
             return TiTiColor.wrongTextField.toColor
@@ -67,17 +68,14 @@ extension SignupPasswordModel {
         }
     }
     
-    // focusState 값변화 수신
+    // @FocusState 값변화 -> stage 반영
     func updateFocus(to focus: SignupTextFieldView.type?) {
         self.focus = focus
         switch focus {
         case .password:
-            validPassword2 = nil
-            password = ""
-            stage = .password
+            resetPassword()
         case .password2:
-            password2 = ""
-            stage = .password2
+            resetPassword2()
         default:
             return
         }
@@ -85,13 +83,11 @@ extension SignupPasswordModel {
     
     func checkPassword() {
         validPassword = PredicateChecker.isValidPassword(password)
+        // stage 변화 -> @StateFocus 반영
         if validPassword == true {
-            validPassword2 = nil
-            password2 = ""
-            stage = .password2
+            resetPassword2()
         } else {
-            password = ""
-            stage = .password
+            resetPassword()
         }
     }
     
@@ -99,9 +95,20 @@ extension SignupPasswordModel {
         let passwordValid = PredicateChecker.isValidPassword(password2)
         let samePassword = password == password2
         validPassword2 = (passwordValid && samePassword)
+        // stage 변화 -> @StateFocus 반영
         if validPassword2 == false {
-            password2 = ""
-            stage = .password2
+            resetPassword2()
         }
+    }
+    
+    private func resetPassword() {
+        validPassword2 = nil
+        password = ""
+        stage = .password
+    }
+    
+    private func resetPassword2() {
+        password2 = ""
+        stage = .password2
     }
 }

--- a/Project_Timer/LoginSignup/Presentation/Signup/Password/SignupPasswordModel.swift
+++ b/Project_Timer/LoginSignup/Presentation/Signup/Password/SignupPasswordModel.swift
@@ -13,12 +13,17 @@ import Combine
 typealias SignupEmailInfos = (prevInfos: SignupSelectInfos, emailInfo: SignupEmailInfo)
 
 class SignupPasswordModel: ObservableObject {
+    enum Stage {
+        case password
+        case password2
+    }
+    
     let infos: SignupEmailInfos
     @Published var contentWidth: CGFloat = .zero
     @Published var focus: SignupTextFieldView.type?
-    @Published var wrongPassword: Bool?
-    @Published var wrongPassword2: Bool?
-    @Published var passwordSuccess: Bool = false
+    @Published var validPassword: Bool?
+    @Published var validPassword2: Bool?
+    @Published var stage: Stage = .password
     
     @Published var password: String = ""
     @Published var password2: String = ""
@@ -29,7 +34,7 @@ class SignupPasswordModel: ObservableObject {
     
     // passwordTextField underline 컬러
     var passwordTintColor: Color {
-        if wrongPassword == true {
+        if validPassword == false {
             return TiTiColor.wrongTextField.toColor
         } else {
             return focus == .password ? Color.blue : UIColor.placeholderText.toColor
@@ -37,7 +42,7 @@ class SignupPasswordModel: ObservableObject {
     }
     
     var password2TintColor: Color {
-        if wrongPassword2 == true {
+        if validPassword2 == false {
             return TiTiColor.wrongTextField.toColor
         } else {
             return focus == .password2 ? Color.blue : UIColor.placeholderText.toColor
@@ -65,17 +70,38 @@ extension SignupPasswordModel {
     // focusState 값변화 수신
     func updateFocus(to focus: SignupTextFieldView.type?) {
         self.focus = focus
+        switch focus {
+        case .password:
+            validPassword2 = nil
+            password = ""
+            stage = .password
+        case .password2:
+            password2 = ""
+            stage = .password2
+        default:
+            return
+        }
     }
     
     func checkPassword() {
-        let passwordValid = PredicateChecker.isValidPassword(password)
-        wrongPassword = !passwordValid
+        validPassword = PredicateChecker.isValidPassword(password)
+        if validPassword == true {
+            validPassword2 = nil
+            password2 = ""
+            stage = .password2
+        } else {
+            password = ""
+            stage = .password
+        }
     }
     
     func checkPassword2() {
         let passwordValid = PredicateChecker.isValidPassword(password2)
         let samePassword = password == password2
-        wrongPassword2 = !(passwordValid && samePassword)
-        passwordSuccess = passwordValid && samePassword
+        validPassword2 = (passwordValid && samePassword)
+        if validPassword2 == false {
+            password2 = ""
+            stage = .password2
+        }
     }
 }

--- a/Project_Timer/LoginSignup/Presentation/Signup/Password/SignupPasswordModel.swift
+++ b/Project_Timer/LoginSignup/Presentation/Signup/Password/SignupPasswordModel.swift
@@ -1,0 +1,81 @@
+//
+//  SignupPasswordModel.swift
+//  Project_Timer
+//
+//  Created by Kang Minsang on 2023/10/30.
+//  Copyright © 2023 FDEE. All rights reserved.
+//
+
+import Foundation
+import SwiftUI
+import Combine
+
+typealias SignupEmailInfos = (prevInfos: SignupSelectInfos, emailInfo: SignupEmailInfo)
+
+class SignupPasswordModel: ObservableObject {
+    let infos: SignupEmailInfos
+    @Published var contentWidth: CGFloat = .zero
+    @Published var focus: SignupTextFieldView.type?
+    @Published var wrongPassword: Bool?
+    @Published var wrongPassword2: Bool?
+    @Published var passwordSuccess: Bool = false
+    
+    @Published var password: String = ""
+    @Published var password2: String = ""
+    
+    init(infos: SignupEmailInfos) {
+        self.infos = infos
+    }
+    
+    // passwordTextField underline 컬러
+    var passwordTintColor: Color {
+        if wrongPassword == true {
+            return TiTiColor.wrongTextField.toColor
+        } else {
+            return focus == .password ? Color.blue : UIColor.placeholderText.toColor
+        }
+    }
+    
+    var password2TintColor: Color {
+        if wrongPassword2 == true {
+            return TiTiColor.wrongTextField.toColor
+        } else {
+            return focus == .password2 ? Color.blue : UIColor.placeholderText.toColor
+        }
+    }
+    
+    // passwordInfo 생성 후 반환
+    var passwordInfo: SignupPasswordInfo {
+        return SignupPasswordInfo(password: password)
+    }
+}
+
+// MARK: Action
+extension SignupPasswordModel {
+    // 화면크기에 따른 width 크기조정
+    func updateContentWidth(size: CGSize) {
+        switch size.deviceDetailType {
+        case .iPhoneMini, .iPhonePro, .iPhoneMax:
+            contentWidth = abs(size.minLength - 48)
+        default:
+            contentWidth = 400
+        }
+    }
+    
+    // focusState 값변화 수신
+    func updateFocus(to focus: SignupTextFieldView.type?) {
+        self.focus = focus
+    }
+    
+    func checkPassword() {
+        let passwordValid = PredicateChecker.isValidPassword(password)
+        wrongPassword = !passwordValid
+    }
+    
+    func checkPassword2() {
+        let passwordValid = PredicateChecker.isValidPassword(password2)
+        let samePassword = password == password2
+        wrongPassword2 = !(passwordValid && samePassword)
+        passwordSuccess = passwordValid && samePassword
+    }
+}

--- a/Project_Timer/LoginSignup/Presentation/Signup/Password/SignupPasswordModel.swift
+++ b/Project_Timer/LoginSignup/Presentation/Signup/Password/SignupPasswordModel.swift
@@ -12,6 +12,7 @@ import Combine
 
 typealias SignupEmailInfos = (prevInfos: SignupSelectInfos, emailInfo: SignupEmailInfo)
 
+// MARK: State
 class SignupPasswordModel: ObservableObject {
     enum Stage {
         case password
@@ -81,6 +82,7 @@ extension SignupPasswordModel {
         }
     }
     
+    // password done 액션
     func checkPassword() {
         validPassword = PredicateChecker.isValidPassword(password)
         // stage 변화 -> @StateFocus 반영
@@ -91,6 +93,7 @@ extension SignupPasswordModel {
         }
     }
     
+    // password2 done 액션
     func checkPassword2() {
         let passwordValid = PredicateChecker.isValidPassword(password2)
         let samePassword = password == password2

--- a/Project_Timer/LoginSignup/Presentation/Signup/Password/SignupPasswordRoute.swift
+++ b/Project_Timer/LoginSignup/Presentation/Signup/Password/SignupPasswordRoute.swift
@@ -1,0 +1,13 @@
+//
+//  SignupPasswordRoute.swift
+//  Project_Timer
+//
+//  Created by Kang Minsang on 2023/10/31.
+//  Copyright © 2023 FDEE. All rights reserved.
+//
+
+import Foundation
+
+enum SignupPasswordRoute {
+    case signupNickname
+}

--- a/Project_Timer/LoginSignup/Presentation/Signup/Password/SignupPasswordView.swift
+++ b/Project_Timer/LoginSignup/Presentation/Signup/Password/SignupPasswordView.swift
@@ -9,7 +9,7 @@
 import SwiftUI
 
 struct SignupPasswordView: View {
-    @EnvironmentObject var environment: LoginSignupEnvironment
+    @ObservedObject private var keyboard = KeyboardResponder.shared
     @StateObject private var model: SignupPasswordModel
     
     init(model: SignupPasswordModel) {
@@ -23,6 +23,7 @@ struct SignupPasswordView: View {
                     .ignoresSafeArea()
                 
                 ContentView(model: model)
+                    .padding(.bottom, keyboard.keyboardHeight+16)
             }
             .onChange(of: geometry.size, perform: { value in
                 model.updateContentWidth(size: value)
@@ -46,55 +47,66 @@ struct SignupPasswordView: View {
             ZStack {
                 ScrollViewReader { scrollViewProxy in
                     ScrollView {
-                        VStack(alignment: .leading, spacing: 0) {
-                            SignupTitleView(title: "비밀번호를 입력해주세요", subTitle: "8자리 이상 비밀번호를 입력해주세요")
-                            
-                            SignupSecureFieldView(type: .password, keyboardType: .alphabet, text: $model.password, focus: $focus) {
-                                model.checkPassword()
+                        HStack {
+                            Spacer()
+                            VStack(alignment: .leading, spacing: 0) {
+                                SignupTitleView(title: "비밀번호를 입력해주세요", subTitle: "8자리 이상 비밀번호를 입력해주세요")
+                                
+                                SignupSecureFieldView(type: .password, keyboardType: .alphabet, text: $model.password, focus: $focus) {
+                                    model.checkPassword()
+                                }
+                                SignupTextFieldUnderlineView(color: model.passwordTintColor)
+                                SignupTextFieldWarning(warning: "영문, 숫자, 또는 10가지 특수문자 내에서 입력해 주세요", visible: model.validPassword == false && model.password.isEmpty)
+                                    .id(SignupTextFieldView.type.password)
+                                
+                                if model.stage == .password2 {
+                                    NextContentView(focus: $focus, model: model, scrollViewProxy: scrollViewProxy)
+                                }
                             }
-                            .id(SignupTextFieldView.type.password)
-                            SignupTextFieldUnderlineView(color: model.passwordTintColor)
-                            SignupTextFieldWarning(warning: "영문, 숫자, 또는 10가지 특수문자 내에서 입력해 주세요", visible: model.validPassword == false)
-                            
-                            if model.stage == .password2 {
-                                NextContentView(focus: $focus, model: model)
+                            .onAppear {
+                                if model.stage == .password {
+                                    focus = .password
+                                }
                             }
-                        }
-                        .onAppear {
-                            if model.stage == .password {
-                                focus = .password
+                            .onChange(of: focus) { newValue in
+                                model.updateFocus(to: newValue)
+                                scroll(scrollViewProxy, to: newValue)
                             }
-                        }
-                        .onChange(of: focus) { newValue in
-                            model.updateFocus(to: newValue)
-                            #if targetEnvironment(macCatalyst)
-                            #else
-                            scrollViewProxy.scrollTo(newValue, anchor: .top)
-                            #endif
-                        }
-                        .onReceive(model.$stage) { status in
-                            switch status {
-                            case .password:
-                                focus = .password
-                            case .password2:
-                                focus = .password2
+                            .onReceive(model.$stage) { status in
+                                switch status {
+                                case .password:
+                                    focus = .password
+                                case .password2:
+                                    focus = .password2
+                                }
+                                scroll(scrollViewProxy, to: focus)
                             }
-                        }
-                        .onReceive(model.$validPassword2) { valid in
-                            if valid == true {
-                                environment.navigationPath.append(SignupPasswordRoute.signupNickname)
+                            .onReceive(model.$validPassword2) { valid in
+                                if valid == true {
+                                    environment.navigationPath.append(SignupPasswordRoute.signupNickname)
+                                }
                             }
+                            .frame(width: model.contentWidth)
+                            Spacer()
                         }
                     }
+                    .scrollIndicators(.hidden)
                 }
             }
-            .frame(width: model.contentWidth)
+        }
+        
+        func scroll(_ scrollViewProxy: ScrollViewProxy, to: any Hashable) {
+            #if targetEnvironment(macCatalyst)
+            #else
+            scrollViewProxy.scrollTo(to, anchor: .bottom)
+            #endif
         }
     }
     
     struct NextContentView: View {
         @FocusState.Binding var focus: SignupTextFieldView.type?
         @ObservedObject var model: SignupPasswordModel
+        let scrollViewProxy: ScrollViewProxy
         
         var body: some View {
             VStack(alignment: .leading, spacing: 0) {
@@ -109,9 +121,9 @@ struct SignupPasswordView: View {
                 SignupSecureFieldView(type: .password2, keyboardType: .alphabet, text: $model.password2, focus: $focus) {
                     model.checkPassword2()
                 }
-                .id(SignupTextFieldView.type.password2)
                 SignupTextFieldUnderlineView(color: model.password2TintColor)
-                SignupTextFieldWarning(warning: "동일하지 않습니다. 다시 입력해 주세요", visible: model.validPassword2 == false)
+                SignupTextFieldWarning(warning: "동일하지 않습니다. 다시 입력해 주세요", visible: model.validPassword2 == false && model.password2.isEmpty)
+                    .id(SignupTextFieldView.type.password2)
             }
         }
     }

--- a/Project_Timer/LoginSignup/Presentation/Signup/Password/SignupPasswordView.swift
+++ b/Project_Timer/LoginSignup/Presentation/Signup/Password/SignupPasswordView.swift
@@ -68,11 +68,11 @@ struct SignupPasswordView: View {
                                     focus = .password
                                 }
                             }
-                            .onChange(of: focus) { newValue in
+                            .onChange(of: focus) { newValue in // @FocusState 변화 -> stage 반영
                                 model.updateFocus(to: newValue)
                                 scroll(scrollViewProxy, to: newValue)
                             }
-                            .onReceive(model.$stage) { status in
+                            .onReceive(model.$stage) { status in // stage 변화 -> @FocusState 반영
                                 switch status {
                                 case .password:
                                     focus = .password

--- a/Project_Timer/LoginSignup/Presentation/Signup/Password/SignupPasswordView.swift
+++ b/Project_Timer/LoginSignup/Presentation/Signup/Password/SignupPasswordView.swift
@@ -60,7 +60,7 @@ struct SignupPasswordView: View {
                                     .id(SignupTextFieldView.type.password)
                                 
                                 if model.stage == .password2 {
-                                    NextContentView(focus: $focus, model: model, scrollViewProxy: scrollViewProxy)
+                                    NextContentView(model: model, focus: $focus)
                                 }
                             }
                             .onAppear {
@@ -94,19 +94,11 @@ struct SignupPasswordView: View {
                 }
             }
         }
-        
-        func scroll(_ scrollViewProxy: ScrollViewProxy, to: any Hashable) {
-            #if targetEnvironment(macCatalyst)
-            #else
-            scrollViewProxy.scrollTo(to, anchor: .bottom)
-            #endif
-        }
     }
     
     struct NextContentView: View {
-        @FocusState.Binding var focus: SignupTextFieldView.type?
         @ObservedObject var model: SignupPasswordModel
-        let scrollViewProxy: ScrollViewProxy
+        @FocusState.Binding var focus: SignupTextFieldView.type?
         
         var body: some View {
             VStack(alignment: .leading, spacing: 0) {

--- a/Project_Timer/LoginSignup/Presentation/Signup/Password/SignupPasswordView.swift
+++ b/Project_Timer/LoginSignup/Presentation/Signup/Password/SignupPasswordView.swift
@@ -1,0 +1,143 @@
+//
+//  SignupPasswordView.swift
+//  Project_Timer
+//
+//  Created by Kang Minsang on 2023/10/30.
+//  Copyright © 2023 FDEE. All rights reserved.
+//
+
+import SwiftUI
+
+struct SignupPasswordView: View {
+    @EnvironmentObject var environment: LoginSignupEnvironment
+    @StateObject private var model: SignupPasswordModel
+    
+    init(model: SignupPasswordModel) {
+        _model = StateObject(wrappedValue: model)
+    }
+    
+    var body: some View {
+        GeometryReader { geometry in
+            ZStack {
+                TiTiColor.firstBackground.toColor
+                    .ignoresSafeArea()
+                
+                ContentView(model: model)
+            }
+            .onChange(of: geometry.size, perform: { value in
+                model.updateContentWidth(size: value)
+            })
+            .navigationDestination(for: SignupPasswordRoute.self) { destination in
+                switch destination {
+                case .signupNickname:
+                    Text("SignupNickName")
+                }
+            }
+        }
+        .configureForTextFieldRootView()
+    }
+    
+    struct ContentView: View {
+        @EnvironmentObject var environment: LoginSignupEnvironment
+        @ObservedObject var model: SignupPasswordModel
+        @FocusState private var focus: SignupTextFieldView.type?
+        
+        var body: some View {
+            ZStack {
+                ScrollViewReader { scrollViewProxy in
+                    ScrollView {
+                        VStack(alignment: .leading, spacing: 0) {
+                            SignupTitleView(title: "비밀번호를 입력해주세요", subTitle: "8자리 이상 비밀번호를 입력해주세요")
+                            
+                            SignupTextFieldView(type: .password, text: $model.password, focus: $focus) {
+                                model.checkPassword()
+                            }
+                            .id(SignupTextFieldView.type.password)
+                            .onChange(of: model.password, perform: { value in
+                                model.wrongPassword = nil
+                            })
+                            SignupTextFieldUnderlineView(color: model.passwordTintColor)
+                            SignupTextFieldWarning(warning: "영문, 숫자, 또는 10가지 특수문자 내에서 입력해 주세요", visible: model.wrongPassword == true)
+                            
+                            if model.wrongPassword == false {
+                                NextContentView(focus: $focus, model: model, checkFocusAfterPassword2: checkFocusAfterPassword2)
+                            }
+                        }
+                        .onAppear {
+                            if model.wrongPassword == nil {
+                                focus = .password
+                            }
+                        }
+                        .onChange(of: focus) { newValue in
+                            model.updateFocus(to: focus)
+                            #if targetEnvironment(macCatalyst)
+                            #else
+                            scrollViewProxy.scrollTo(newValue, anchor: .top)
+                            #endif
+                        }
+                        .onReceive(model.$passwordSuccess) { success in
+                            guard success else { return }
+                            environment.navigationPath.append(SignupPasswordRoute.signupNickname)
+                        }
+                    }
+                }
+            }
+            .frame(width: 393-48)
+        }
+        
+        func checkFocusAfterPassword() {
+            if model.wrongPassword == true {
+                focus = .password
+            }
+        }
+        
+        func checkFocusAfterPassword2() {
+            if model.passwordSuccess == false {
+                focus = .password2
+            }
+        }
+    }
+    
+    struct NextContentView: View {
+        @FocusState.Binding var focus: SignupTextFieldView.type?
+        @ObservedObject var model: SignupPasswordModel
+        var checkFocusAfterPassword2: () -> Void
+        
+        var body: some View {
+            VStack(alignment: .leading, spacing: 0) {
+                Spacer()
+                    .frame(height: 35)
+                Text("다시 한번 입력해 주세요")
+                    .font(TiTiFont.HGGGothicssiP60g(size: 14))
+                    .foregroundStyle(Color.primary)
+                Spacer()
+                    .frame(height: 16)
+                
+                SignupTextFieldView(type: .password2, text: $model.password2, focus: $focus) {
+                    model.checkPassword2()
+                    checkFocusAfterPassword2()
+                }
+                .id(SignupTextFieldView.type.password2)
+                .onChange(of: model.password2, perform: { value in
+                    model.wrongPassword2 = nil
+                })
+                SignupTextFieldUnderlineView(color: model.password2TintColor)
+                SignupTextFieldWarning(warning: "동일하지 않습니다. 다시 입력해 주세요", visible: model.wrongPassword2 == true)
+            }
+            .onAppear {
+                if model.wrongPassword2 != false {
+                    focus = .password2
+                }
+            }
+        }
+    }
+}
+
+struct SignupPasswordView_Previews: PreviewProvider {
+    static let prevInfos: SignupSelectInfos = (type: .normal, venderInfo: nil)
+    static let emailInfo: SignupEmailInfo = SignupEmailInfo(email: "freedeveloper97@gmail.com", verificationKey: "abcd1234")
+    
+    static var previews: some View {
+        SignupPasswordView(model: SignupPasswordModel(infos: (prevInfos: prevInfos, emailInfo: emailInfo))).environmentObject(LoginSignupEnvironment())
+    }
+}


### PR DESCRIPTION
## 개요
- Issue:  #114 
- Tech Spec: [회원 관리 기능 개발](https://www.notion.so/timertiti/4cb5c74f656e4bf784cff130213fd086?pvs=4)
- Figma: [로그인 프로세스](https://www.figma.com/file/T8hsaAguFkPytBiNMOOw03/Develop?type=design&node-id=670-9559&mode=design)

---

## 변경사항
- [x] SignupSecureFieldView 생성
- [x] OverlayShowButtonForSecureFieldView 모디파이어 생성
- [x] SignupPasswordModel 생성
- [x] SignupPasswordView 생성
- [x] `enum` Stage & `@FocusStatus`를 활용하여 TextField 전환 및 순서 로직 개발
- [x] 기타 개선
  - [x] KeyboardResponder singleton 형태로 개선
  - [x] `onReceive` 모디파이어를 통한 Model의 Publisher 변화 -> 로직수행으로 개선
  - [x] ScrollView 내 HStack을 통해 여백까지 스크롤 가능하도록 개선

| 아이폰 동작 | 아이패드 동작 |
| -------- | -------- |
| <img src="https://github.com/TimerTiTi/TiTi_iOS/assets/65349445/13d570aa-3801-4184-bc2f-df3dcd7d4fd8"> | <img src="https://github.com/TimerTiTi/TiTi_iOS/assets/65349445/077ae732-682a-4599-aeae-ea64a74cbbad"> |
<br>

## Model
- SwiftUI로 개발하면서 `데이터 및 UI 상태들을 Model` 내 지닐 수 있도록 개선하였다.
- `@StateObject`를 사용하여 `@Published` 변수들을 지녔다.
- Model 내 지닐 수 없는 `@FocusState`, `@Environment` 만 View 내 위치한 형태로 개발하였다.
- 관련된 내용은 이전 PR를 참고: [#115: 이메일 입력화면 Model 생성, Common View로 분리 및 개선](https://github.com/TimerTiTi/TiTi_iOS/pull/115)
<br>

## View 내 @FocusState 와 Model 내 @Published 값 간의 데이터흐름 고민
`@FocusState`의 경우 `@StateObject` 내 지니기엔 많은 문제가 발생하였다.
따라서 고민 후 View 내 지닌채로 비즈니스 로직과 관련하여 Model 내 추가로 값을 지니며 이 둘간의 `데이터 흐름`에 대해 고민하였다.

### @FocusState 값 변화 -> @Published 값 반영
- focus 값 자체의 변화의 경우 `onChange` 모디파이어를 통해 수신할 수 있었다.
- `onChange` 모디파이어 내에서 `model.updateFocus()` 메소드를 통해 `@Published` 값을 반영하였다.
- 다만, `@FocusState` 값만으로는 현재 진행중인 상태를 모두 설명할수는 없었기에 Model 내 추가적인 `stage` 값을 지닌 형태로 구현하였다.

### @Published 값 변화 -> @FocusState 값 반영
- Model 내에서 비즈니스로직으로 인해 `@Published` 값이 변화된다.
- View 내에서 `.onReceive` 모디파이어를 통해 publisher 값변화 수신할 수 있었다.
- onReceive 모디파이어 내에서 `@Published` 값에 따라 분기처리하여 `@FocusState` 값을 반영하였다.

추가적인 에러상황
- `@FocusState`의 경우 publisher를 사용할 수 없는 형태였다.
- 따라서 오로지 값 자체가 변화되는 경우만 `onChange` 모디파이어를 통해 수신할 수 있었다.
- 입력된 비밀번호가 정규식에 올바르지 않아 `@FocusState 값을 동일하게 설정`한 경우에도 `onChange 모디파이어는 수신되지 않았다.`
- 따라서 Model 내 `@Published` 값 변화를 사용하여 `onReceive` 모디파이어 내에서 `onChange` 모디파이어 내 `중복되는 로직`이 필요할 수 밖에 없는 상황이 있었다.
- `@FocusState` 값을 `@StateObject` 내에서 안전하게 `@Published` 형태로 사용할 수 있다면 해결될 것 같지만, 현재로선 해당방법이 최선으로 보여진다.
<br>

## 앵프라맹스 구현 내용
- 비밀번호 입력 화면을 만들면서 여러가지 목표들이 있었다.
- 특히 `SecureField`와 `@FocusState`를 사용하면서 몇가지 이슈가 생겼었고, 이러한 것들을 각 앵프라맹스 목표별로 나열하겠다.
<br>

### 화면에 진입시 자동으로 passwordTextField가 활성화되며 키보드가 표시된다.
- `onAppear` 모디파이어 내에서 `@FocusState` 값을 설정하여 키보드를 표시하였다.
- 다만 NavigationStack 에서 뒤로 이동하는 경우도 있기에 상황 분기처리를 넣었다.
```swift
.onAppear {
    if model.stage == .password {
        focus = .password
    }
}
```
<br>

### SecureField에 입력시 첫글자는 원문으로 보여야 한다.
- `SecureField`를 사용시 기본적으로 첫글자는 원문으로 보인다.
- 하지만 `.onChange` 모디파이어를 사용하여 text내용에 따른 `UI 분기처리`가 존재하는 경우 `첫글자가 원문으로 보이지 않는 현상`이 발생하였다.
- 따라서 `.onChange` 모디파이어를 `제거`하였고, text 내용에 따른 경고문 표시여부의 경우 model 내 `computed property` 를 통해 해결하였다.
```swift
SignupSecureFieldView(type: .password, keyboardType: .alphabet, text: $model.password, focus: $focus) {
    model.checkPassword()
}
SignupTextFieldUnderlineView(color: model.passwordTintColor)
```
```swift
// passwordTextField underline 컬러
var passwordTintColor: Color {
    if validPassword == false && password.isEmpty {
        return TiTiColor.wrongTextField.toColor
    } else {
        return focus == .password ? Color.blue : UIColor.placeholderText.toColor
    }
}
```
<br>

### SecureField 우측에 눈 아이콘을 통해 원문을 볼 수 있어야 한다.
- `SecureField` 에서 원문을 표시할 수 있는 기능이 없었다.
- 따라서 `상태에 따라 TextField로 표시`되도록 구현하는것이 필요하였다.
- `ZStack` 내 TextField, SecureField를 넣었고, `.opacity`를 통해 상황에 따라 표시되도록 구현하였다.
- `.opacity`를 사용하는 방법이 `@FocusState`로인한 문제가 발생하지 않는 유일한 방법으로 보였다.
- 원문을 표시할 지 선택하기 위한 버튼의 경우 `.overlayShowButtonForSecureFieldView` 모디파이어를 생성하여 적용하였다.
```swift
struct OverlayShowButtonForSecureFieldView: ViewModifier {
    var isVisible: Bool
    var isSecure: Bool
    var action: () -> Void
    
    func body(content: Content) -> some View {
        content
            .overlay {
                if isVisible {
                    HStack {
                        Spacer()
                        Button {
                            action()
                        } label: {
                            Image(systemName: isSecure ? "eye.slash" : "eye")
                        }
                        .foregroundColor(.secondary)
                    }
                }
                
            }
    }
}
```
```swift
struct SignupSecureFieldView: View {
    ...
    @Binding var text: String
    @FocusState.Binding var focus: SignupTextFieldView.type?
    let submitAction: () -> Void
    @State private var isSecure: Bool = true
    
    var body: some View {
        ZStack {
            TextField("", text: $text)
                ...
                .focused($focus, equals: self.type) // textField 활성화값 반영
                .overlayShowButtonForSecureFieldView(isVisible: isVisible, isSecure: isSecure, action: {
                    isSecure.toggle()
                })
                .opacity(isSecure ? 0 : 1)
            
            SecureField("", text: $text)
                ...
                .focused($focus, equals: self.type) // textField 활성화값 반영
                .overlayShowButtonForSecureFieldView(isVisible: isVisible, isSecure: isSecure, action: {
                    isSecure.toggle()
                })
                .opacity(isSecure ? 1 : 0)
        }
        .onChange(of: focus) { newValue in
            if newValue == nil {
                isSecure = true
            }
        }
    }
    ...
}
```
<br>

### SecureTextField 에 원문이 표시된채로 입력할 수 있어야 한다.
- 위 SignupSecureFieldView 코드에서 `TextField` 와 `SecureField` 내 동일한 `$text` 값을 사용하였다.
- 따라서 `opacity`로 인해 `SecureField`가 가려져도 입력된 값이 `TextField`로 표시가 되었다.
<br>

### SecureTextField 입력이 완료되면 secure 상태로 표시되어야 한다.
- 위 SignupSecureFieldView 코드에서 `.onChange(of: focus)` 모디파이어를 통해 비활성화 되었을 경우 `isSecure` 값을 true로 설정하여 원문이 표시되지 않도록 하였다.
<br>

### 키보드의 done 버튼을 눌러 다음 TextField로 이동한다.
- SignupSecureTextField 내 `.submitLabel` 모디파이어와 `.onSubmit` 모디파이어를 적용하여 done 버튼이 표시되도록 하였다.
- done 버튼을 누르면 클로저로 받은 것을 수행되도록 하였다.
```swift
struct SignupSecureFieldView: View {
    ...
    let submitAction: () -> Void
    
    var body: some View {
        ZStack {
            TextField("", text: $text)
                ...
                .submitLabel(.done) // 키보드 done 버튼 활성화
                .onSubmit { // 키보드 done 버튼 액션
                    submitAction()
                }
            
            SecureField("", text: $text)
                ...
                .submitLabel(.done) // 키보드 done 버튼 활성화
                .onSubmit { // 키보드 done 버튼 액션
                    submitAction()
                }
        }
        ...
    }
    ...
}
```
<br>

### 만약 정규식에 어긋나는 경우 TextField가 그대로 유지되며 text는 지워진채로 하단에 경고문이 표시되며 빨간색으로 표시되어야 한다.
- 키보드의 done 버튼이 눌리면 클로저로 전달된 `model.checkPassword()` 메소드가 실행된다.
- model 내에서 정규식 체크를 통해 @Published `validPassword` 값을 설정한다.
- model 내에서 `validPassword` 값이 false인 경우 `resetPassword2()` 메소드가 실행되어 text가 지워지며 stage 값을 설정한다.
- model 내 `resetPassword2()` 메소드로 인해 `stage` 값이 변경되면 `onReceive` 모디파이어를 통해 수신받는다.
- onReceive 모디파이어 내에서 validPassword가 false 인 경우 `@FocusState` 값을 `.password`로 설정하여 TextField가 유지되도록 한다.
- 빨간색 표시와 경고문의 경우 model 내 validPassword 값과 password 값을 비교하여 빨간색으로 표시된다.
```swift
struct ContentView: View {
    @ObservedObject var model: SignupPasswordModel
    @FocusState private var focus: SignupTextFieldView.type?
    
    var body: some View {
        ...
        VStack(alignment: .leading, spacing: 0) {
            ...
            SignupSecureFieldView(type: .password, keyboardType: .alphabet, text: $model.password, focus: $focus) {
                model.checkPassword()
            }
            SignupTextFieldUnderlineView(color: model.passwordTintColor)
            SignupTextFieldWarning(warning: "영문, 숫자, 또는 10가지 특수문자 내에서 입력해 주세요", visible: model.validPassword == false && model.password.isEmpty)
        }
        ...
        .onReceive(model.$stage) { stage in // stage 변화 -> @FocusState 반영
            switch stage {
            case .password:
                focus = .password
            case .password2:
                focus = .password2
            }
            scroll(scrollViewProxy, to: focus)
        }
    }
}
```
```swift
class SignupPasswordModel: ObservableObject {
    enum Stage {
        case password
        case password2
    }
    ...
    @Published var validPassword: Bool?
    @Published var stage: Stage = .password
    @Published var password: String = ""
    
    // passwordTextField underline 컬러
    var passwordTintColor: Color {
        if validPassword == false && password.isEmpty {
            return TiTiColor.wrongTextField.toColor
        } else {
            return focus == .password ? Color.blue : UIColor.placeholderText.toColor
        }
    }
}

extension SignupPasswordModel {
    ...
    // password done 액션
    func checkPassword() {
        validPassword = PredicateChecker.isValidPassword(password)
        // stage 변화 -> @FocusState 반영
        if validPassword == true {
            resetPassword2()
        } else {
            resetPassword()
        }
    }
    
    private func resetPassword() {
        validPassword2 = nil
        password = ""
        stage = .password
    }
}
```
<br>

### TextField의 값이 입력되면 빨간색에서 파란색으로 변경되어 표시되어야 한다.
- 위 코드내에서 model 내 `computed property` 값인 `passwordTintColor` 값 내에서 색을 반환한다.
- `onChange`를 통해 text의 값 변경을 수신하여 UI를 표시하는 경우 `SecureField의 첫글자가 원문으로 표시되지 않는 문제`가 발생하였다.
- 따라서 computed property 내에서 `password.isEmpty` 를 확인하는 식으로 구현하였다.
<br>

### 비밀번호를 다시 변경하고자 TextField를 선택시 이후에 입력된 TextField는 초기화되며 사라져야 한다.
- 비밀번호 재입력이 표시된 상태에서 비밀번호를 입력하는 SecureTextField를 선택시 `@FocusState` 값이 변경된다.
- `@FocusState` 값의 변경을 `onChange` 모디파이어를 통해 수신한다.
- onChange 모디파이어 내에서 `model.updateFocus(to: focus)` 메소드를 실행한다.
- `updateFocus` 메소드 내에서 선택된 focus 값에 따라 `stage` 값을 변경하며, 이후에 입력된 데이터를 초기화한다.
- `stage` 값 변화로 인해 비밀번호 재입력 표시가 사라진다.
```swift
struct ContentView: View {
    @ObservedObject var model: SignupPasswordModel
    @FocusState private var focus: SignupTextFieldView.type?
    
    var body: some View {
        ...
        VStack(alignment: .leading, spacing: 0) {
            ...
            SignupSecureFieldView(type: .password, keyboardType: .alphabet, text: $model.password, focus: $focus) {
                model.checkPassword()
            }

            if model.stage == .password2 {
                NextContentView(model: model, focus: $focus)
            }
        }
        ...
        .onChange(of: focus) { newValue in // @FocusState 변화 -> stage 반영
            model.updateFocus(to: newValue)
            scroll(scrollViewProxy, to: newValue)
        }
    }
}
```
```swift
class SignupPasswordModel: ObservableObject {
    enum Stage {
        case password
        case password2
    }
    ...
    @Published var focus: SignupTextFieldView.type?
    @Published var validPassword: Bool?
    @Published var validPassword2: Bool?
    @Published var stage: Stage = .password
    
    @Published var password: String = ""
    @Published var password2: String = ""
    ...
}

extension SignupPasswordModel {
    ...
    // @FocusState 값변화 -> stage 반영
    func updateFocus(to focus: SignupTextFieldView.type?) {
        self.focus = focus
        switch focus {
        case .password:
            resetPassword()
        case .password2:
            resetPassword2()
        default:
            return
        }
    }
    
    private func resetPassword() {
        validPassword2 = nil
        password = ""
        stage = .password
    }
    
    private func resetPassword2() {
        password2 = ""
        stage = .password2
    }
}
```
<br>

### 아이패드의 경우 TextField 활성화에 따라 스크롤되어 화면에 가려지지 않도록 한다.
- ContentView 내 body를 `ScrollViewReader`, `ScrollView` 내 컨텐츠를 표시하는 식으로 구현하였다.
- `@FocusState` 값에 따라 scrollViewReader`.scrollTo` 모디파이어를 통해 스크롤되도록 구현하였다.
- 원하는 위치로 스크롤이 되도록 하기 위하여 `id` 값들을 부여하였다.
- 또한 표시된 키보드의 높이만큼 하단 `.padding`을 추가하여 정상적으로 스크롤이 이동되어 가려지지 않도록 구현하였다.
- 다만, 맥의 경우는 관련없어야 하므로 `#if targetEnvironment(macCatalyst)` 분기처리가 추가되었다.
```swift
extension View {
    func sscroll(_ scrollViewProxy: ScrollViewProxy, to: any Hashable) {
        #if targetEnvironment(macCatalyst)
        #else
        scrollViewProxy.scrollTo(to, anchor: .bottom)
        #endif
    }
}
```
```swift
struct ContentView: View {
    @EnvironmentObject var environment: LoginSignupEnvironment
    @ObservedObject var model: SignupPasswordModel
    @FocusState private var focus: SignupTextFieldView.type?
    
    var body: some View {
        ZStack {
            ScrollViewReader { scrollViewProxy in
                ScrollView {
                    HStack {
                        Spacer()
                        VStack(alignment: .leading, spacing: 0) {
                            ...
                            SignupTextFieldWarning(warning: "영문, 숫자, 또는 10가지 특수문자 내에서 입력해 주세요", visible: model.validPassword == false && model.password.isEmpty)
                                .id(SignupTextFieldView.type.password)
                            
                            if model.stage == .password2 {
                                NextContentView(model: model, focus: $focus)
                            }
                        }
                        ...
                        .onChange(of: focus) { newValue in // @FocusState 변화 -> stage 반영
                            model.updateFocus(to: newValue)
                            scroll(scrollViewProxy, to: newValue)
                        }
                        .onReceive(model.$stage) { status in // stage 변화 -> @FocusState 반영
                            switch status {
                            case .password:
                                focus = .password
                            case .password2:
                                focus = .password2
                            }
                            scroll(scrollViewProxy, to: focus)
                        }
                        .frame(width: model.contentWidth) // vstack end
                        Spacer()
                    }
                }
                .scrollIndicators(.hidden)
            }
        }
    }
}
```
```swift
struct NextContentView: View {
    @FocusState.Binding var focus: SignupTextFieldView.type?
    
    var body: some View {
        VStack(alignment: .leading, spacing: 0) {
            ...
            SignupTextFieldWarning(warning: "동일하지 않습니다. 다시 입력해 주세요", visible: model.validPassword2 == false && model.password2.isEmpty)
                .id(SignupTextFieldView.type.password2)
        }
    }
}
```
<br>

### 아이패드의 경우 우측 여백을 통해 스크롤이 될 수 있도록 한다.
- 위 ContentView 내 body 코드에서 `ScrollView` 내 `HStack`을 표시하도록 하였다.
- `HStack` 내 VStack으로 표시되는 컨텐츠 양옆에 `Spacer()`를 추가하였다.
- 최종적으로 양옆에 Spacer()로 채워진 ScrollView 내 `.frame(width: model.contentWidth)`로 width가 설정된 컨텐츠가 중앙에 표시되도록 하였다.
- 이를 통해 양옆의 여백으로도 스크롤이 되도록 구현하였다.
<br>

### 최종적으로, 사용자는 키보드 입력과 done 버튼만으로 모든것을 할 수 있어야 한다.
- 위 내용들에 따라 done 버튼을 통해 `model.checkPassword()` 메소드가 실행된다.
- 상황에 따라 `stage` 값이 변화되어 `@FocusState`까지 변화되도록 구현하였다.
<br>

### 또한 사용자가 선택한 TextField에 따라 초기화되어 표시되어야 한다.
- TextField를 선택시 `@FocusState` 값이 변화된다.
- 위 내용들에 따라 `@FocusState` 값 변화를 `onChange` 모디파이어를 통해 수신하여 `model.updateFocus()` 메소드가 실행된다.
- 상황에 따라 `stage` 값이 변화되어 UI가 변화되어 표시되도록 구현하였다.
<br>

### @StateObject를 활용하여 Model 내 UI상태값들을 지닌 상태로 개발
- 위 내용들에 따라 `@EnvironmentObject`, `@FocusState` 만 제외한 나머지 모든 값들을 `@Published` 값으로 `@StateObject` 내 지니도록 구현하였다.
<br>

## Reference
- [SwiftUI show/hide password text input](https://medium.com/@chinthaka01/swiftui-show-hide-password-text-input-field-86fc8fea4660)
- [Show/Hide Password - How can I add this feature?](https://stackoverflow.com/questions/63095851/show-hide-password-how-can-i-add-this-feature)
- [How to use @FocusState with view models?](https://stackoverflow.com/questions/70133763/how-to-use-focusstate-with-view-models)
