### PR TITLE
닉네임 입력 화면 개발

### DIFF
--- a/Project_Timer.xcodeproj/project.pbxproj
+++ b/Project_Timer.xcodeproj/project.pbxproj
@@ -189,6 +189,8 @@
 		878DA1F62AEE617900C60CBF /* SignupInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 878DA1F52AEE617900C60CBF /* SignupInfo.swift */; };
 		878DA1F82AEE68DA00C60CBF /* SignupEmailModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 878DA1F72AEE68DA00C60CBF /* SignupEmailModel.swift */; };
 		878DA1FD2AEF7CEF00C60CBF /* ConfigureForTextFieldRootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 878DA1FC2AEF7CEF00C60CBF /* ConfigureForTextFieldRootView.swift */; };
+		878DA81F2B0C62A9001E924E /* SignupNicknameModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 878DA81E2B0C62A9001E924E /* SignupNicknameModel.swift */; };
+		878DA8212B0C62E1001E924E /* SignupNicknameView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 878DA8202B0C62E1001E924E /* SignupNicknameView.swift */; };
 		879053FF29558EF4008B9258 /* SyncUserStatusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 879053FE29558EF4008B9258 /* SyncUserStatusView.swift */; };
 		8791081F28387537005D7B10 /* NetworkURL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8791081E28387537005D7B10 /* NetworkURL.swift */; };
 		87910821283875C0005D7B10 /* NetworkController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87910820283875C0005D7B10 /* NetworkController.swift */; };
@@ -504,6 +506,8 @@
 		878DA1F52AEE617900C60CBF /* SignupInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignupInfo.swift; sourceTree = "<group>"; };
 		878DA1F72AEE68DA00C60CBF /* SignupEmailModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignupEmailModel.swift; sourceTree = "<group>"; };
 		878DA1FC2AEF7CEF00C60CBF /* ConfigureForTextFieldRootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigureForTextFieldRootView.swift; sourceTree = "<group>"; };
+		878DA81E2B0C62A9001E924E /* SignupNicknameModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignupNicknameModel.swift; sourceTree = "<group>"; };
+		878DA8202B0C62E1001E924E /* SignupNicknameView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignupNicknameView.swift; sourceTree = "<group>"; };
 		879053FE29558EF4008B9258 /* SyncUserStatusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncUserStatusView.swift; sourceTree = "<group>"; };
 		8791081E28387537005D7B10 /* NetworkURL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkURL.swift; sourceTree = "<group>"; };
 		87910820283875C0005D7B10 /* NetworkController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkController.swift; sourceTree = "<group>"; };
@@ -1119,6 +1123,15 @@
 			path = Modifier;
 			sourceTree = "<group>";
 		};
+		878DA81D2B0C6271001E924E /* Nickname */ = {
+			isa = PBXGroup;
+			children = (
+				878DA8202B0C62E1001E924E /* SignupNicknameView.swift */,
+				878DA81E2B0C62A9001E924E /* SignupNicknameModel.swift */,
+			);
+			path = Nickname;
+			sourceTree = "<group>";
+		};
 		879053FD29558ED2008B9258 /* SyncDailys */ = {
 			isa = PBXGroup;
 			children = (
@@ -1505,6 +1518,7 @@
 			children = (
 				878DA1F32AEE610F00C60CBF /* Email */,
 				870F90E12AEFF7DE00854DDB /* Password */,
+				878DA81D2B0C6271001E924E /* Nickname */,
 			);
 			path = Signup;
 			sourceTree = "<group>";
@@ -1968,7 +1982,9 @@
 				879E849C29C83D5100D65F48 /* RoundedShape.swift in Sources */,
 				87199F582883F2E00017D01A /* TimelineVM.swift in Sources */,
 				877036CA29CD7B3B0078A30C /* TaskManager.swift in Sources */,
+				878DA8212B0C62E1001E924E /* SignupNicknameView.swift in Sources */,
 				048D8ACB28AA49F800A2456D /* PopupEditHistoryVC.swift in Sources */,
+				878DA81F2B0C62A9001E924E /* SignupNicknameModel.swift in Sources */,
 				043706332869FB9F00A5D3AA /* StopwatchTimeLabelVM.swift in Sources */,
 				87BEBEEF281CD7EC0095CD29 /* UIViewController+Extension.swift in Sources */,
 				87D4C95A28950B4E008ECAA4 /* WeekDailysData.swift in Sources */,

--- a/Project_Timer.xcodeproj/project.pbxproj
+++ b/Project_Timer.xcodeproj/project.pbxproj
@@ -191,6 +191,7 @@
 		878DA1FD2AEF7CEF00C60CBF /* ConfigureForTextFieldRootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 878DA1FC2AEF7CEF00C60CBF /* ConfigureForTextFieldRootView.swift */; };
 		878DA81F2B0C62A9001E924E /* SignupNicknameModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 878DA81E2B0C62A9001E924E /* SignupNicknameModel.swift */; };
 		878DA8212B0C62E1001E924E /* SignupNicknameView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 878DA8202B0C62E1001E924E /* SignupNicknameView.swift */; };
+		878DA8232B0C6B1E001E924E /* LoginSelectModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 878DA8222B0C6B1E001E924E /* LoginSelectModel.swift */; };
 		879053FF29558EF4008B9258 /* SyncUserStatusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 879053FE29558EF4008B9258 /* SyncUserStatusView.swift */; };
 		8791081F28387537005D7B10 /* NetworkURL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8791081E28387537005D7B10 /* NetworkURL.swift */; };
 		87910821283875C0005D7B10 /* NetworkController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87910820283875C0005D7B10 /* NetworkController.swift */; };
@@ -508,6 +509,7 @@
 		878DA1FC2AEF7CEF00C60CBF /* ConfigureForTextFieldRootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigureForTextFieldRootView.swift; sourceTree = "<group>"; };
 		878DA81E2B0C62A9001E924E /* SignupNicknameModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignupNicknameModel.swift; sourceTree = "<group>"; };
 		878DA8202B0C62E1001E924E /* SignupNicknameView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignupNicknameView.swift; sourceTree = "<group>"; };
+		878DA8222B0C6B1E001E924E /* LoginSelectModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginSelectModel.swift; sourceTree = "<group>"; };
 		879053FE29558EF4008B9258 /* SyncUserStatusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncUserStatusView.swift; sourceTree = "<group>"; };
 		8791081E28387537005D7B10 /* NetworkURL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkURL.swift; sourceTree = "<group>"; };
 		87910820283875C0005D7B10 /* NetworkController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkController.swift; sourceTree = "<group>"; };
@@ -864,6 +866,7 @@
 			children = (
 				87B7A53B2AC02202002AFDFE /* LoginSelectRoute.swift */,
 				874F9C2A2ABFF51700675A86 /* LoginSelectView.swift */,
+				878DA8222B0C6B1E001E924E /* LoginSelectModel.swift */,
 				874F9C2C2ABFF73400675A86 /* AppleLoginButton.swift */,
 				874F9C2E2ABFF7CF00675A86 /* GoogleLoginButton.swift */,
 				874F9C302ABFF81300675A86 /* EmailLoginButton.swift */,
@@ -1951,6 +1954,7 @@
 				8760FCB929541BE3000BCCD1 /* KeyChain.swift in Sources */,
 				87D5E65328C7477100D53F8D /* MonthTime.swift in Sources */,
 				87D7ED152952B3C100121DE6 /* TestUserSignupInfo.swift in Sources */,
+				878DA8232B0C6B1E001E924E /* LoginSelectModel.swift in Sources */,
 				04504C642864C7F500CA4C69 /* BaseTimeLabelView.swift in Sources */,
 				04504C5B286485BE00CA4C69 /* BaseSingleTimeLabelView.swift in Sources */,
 				87789E42288BBD0900759C01 /* DayOfWeekLabel.swift in Sources */,

--- a/Project_Timer.xcodeproj/project.pbxproj
+++ b/Project_Timer.xcodeproj/project.pbxproj
@@ -192,6 +192,7 @@
 		878DA81F2B0C62A9001E924E /* SignupNicknameModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 878DA81E2B0C62A9001E924E /* SignupNicknameModel.swift */; };
 		878DA8212B0C62E1001E924E /* SignupNicknameView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 878DA8202B0C62E1001E924E /* SignupNicknameView.swift */; };
 		878DA8232B0C6B1E001E924E /* LoginSelectModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 878DA8222B0C6B1E001E924E /* LoginSelectModel.swift */; };
+		878DA8252B0C78D8001E924E /* SignupNicknameRoute.swift in Sources */ = {isa = PBXBuildFile; fileRef = 878DA8242B0C78D8001E924E /* SignupNicknameRoute.swift */; };
 		879053FF29558EF4008B9258 /* SyncUserStatusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 879053FE29558EF4008B9258 /* SyncUserStatusView.swift */; };
 		8791081F28387537005D7B10 /* NetworkURL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8791081E28387537005D7B10 /* NetworkURL.swift */; };
 		87910821283875C0005D7B10 /* NetworkController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87910820283875C0005D7B10 /* NetworkController.swift */; };
@@ -510,6 +511,7 @@
 		878DA81E2B0C62A9001E924E /* SignupNicknameModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignupNicknameModel.swift; sourceTree = "<group>"; };
 		878DA8202B0C62E1001E924E /* SignupNicknameView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignupNicknameView.swift; sourceTree = "<group>"; };
 		878DA8222B0C6B1E001E924E /* LoginSelectModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginSelectModel.swift; sourceTree = "<group>"; };
+		878DA8242B0C78D8001E924E /* SignupNicknameRoute.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignupNicknameRoute.swift; sourceTree = "<group>"; };
 		879053FE29558EF4008B9258 /* SyncUserStatusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncUserStatusView.swift; sourceTree = "<group>"; };
 		8791081E28387537005D7B10 /* NetworkURL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkURL.swift; sourceTree = "<group>"; };
 		87910820283875C0005D7B10 /* NetworkController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkController.swift; sourceTree = "<group>"; };
@@ -1129,6 +1131,7 @@
 		878DA81D2B0C6271001E924E /* Nickname */ = {
 			isa = PBXGroup;
 			children = (
+				878DA8242B0C78D8001E924E /* SignupNicknameRoute.swift */,
 				878DA8202B0C62E1001E924E /* SignupNicknameView.swift */,
 				878DA81E2B0C62A9001E924E /* SignupNicknameModel.swift */,
 			);
@@ -1900,6 +1903,7 @@
 				87DB923E2AC2D06C00FE6453 /* View+Extension.swift in Sources */,
 				043706272869D58C00A5D3AA /* TimerTimeLabelView.swift in Sources */,
 				874F9C312ABFF81300675A86 /* EmailLoginButton.swift in Sources */,
+				878DA8252B0C78D8001E924E /* SignupNicknameRoute.swift in Sources */,
 				870F90E52AEFFA9300854DDB /* SignupPasswordModel.swift in Sources */,
 				878899822894F05F00B7F378 /* StandardWeekTaskCell.swift in Sources */,
 				877911B82A18903000F0A713 /* SettingListCell.swift in Sources */,

--- a/Project_Timer/Global/SingletonClass/PredicateChecker.swift
+++ b/Project_Timer/Global/SingletonClass/PredicateChecker.swift
@@ -13,6 +13,7 @@ struct PredicateChecker {
     
     static let emailCheck = "[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,64}" // email 형식
     static let passwordCheck = "^(?=.*[A-Za-z])(?=.*[0-9])(?=.*[\(allowedSpecialCharacters)]).*$" // 8자리 ~ 20자리 영어 + 숫자 + 허용된 특수문자
+    static let nicknameCheck = "[A-Z0-9a-z,./<>?;':!@#$%^&*()-=_+]{2,12}" // 닉네임 형식
     
     static func resultOfPredicate(text: String, cheker: String) -> Bool {
         let predicate = NSPredicate(format: "SELF MATCHES %@", cheker)
@@ -25,5 +26,9 @@ struct PredicateChecker {
     
     static func isValidPassword(_ password: String) -> Bool {
         return resultOfPredicate(text: password, cheker: passwordCheck) && password.count >= 8 && password.count <= 20
+    }
+    
+    static func isValidNickname(_ nickname: String) -> Bool {
+        return resultOfPredicate(text: nickname, cheker: nicknameCheck)
     }
 }

--- a/Project_Timer/LoginSignup/Domain/SignupInfo.swift
+++ b/Project_Timer/LoginSignup/Domain/SignupInfo.swift
@@ -65,5 +65,5 @@ struct SignupInfosForNickname {
     let type: SignupType
     let venderInfo: SignupVenderInfo?
     let emailInfo: SignupEmailInfo
-    let passwordInfo: SignupPasswordInfo
+    let passwordInfo: SignupPasswordInfo?
 }

--- a/Project_Timer/LoginSignup/Domain/SignupInfo.swift
+++ b/Project_Timer/LoginSignup/Domain/SignupInfo.swift
@@ -9,37 +9,54 @@
 import Foundation
 import Combine
 
+// MARK: Info
+/// 회원가입 type
+enum SignupType {
+    case normal
+    case vender
+    case venderWithEmail
+}
+
+/// vender 정보
+struct SignupVenderInfo {
+    enum vender {
+        case apple
+        case google
+    }
+    let vender: vender
+    let id: String
+    let email: String?
+}
+
+/// email 정보
 struct SignupEmailInfo {
     let email: String
     let verificationKey: String
 }
 
+/// password 정보
 struct SignupPasswordInfo {
     let password: String
 }
 
-struct SignupVenderInfo {
-    let vender: SignupInfo.vender
-    let id: String
-    let email: String?
-}
-
+/// nickname 정보
 struct SignupNicknameInfo {
     let nickname: String
 }
 
+/// marketing 정보
 struct SignupTermsInfo {
     let marketingObservable: Bool
 }
 
-struct SignupInfo {
-    enum type {
-        case normal
-        case vender
-        case venderWithEmail
-    }
-    enum vender {
-        case apple
-        case google
-    }
+// MARK: Infos
+struct SignupInfosForEmail {
+    let type: SignupType
+    let venderInfo: SignupVenderInfo?
+}
+
+struct SignupInfosForPassword {
+    let type: SignupType
+    let venderInfo: SignupVenderInfo?
+    let emailInfo: SignupEmailInfo
 }

--- a/Project_Timer/LoginSignup/Domain/SignupInfo.swift
+++ b/Project_Timer/LoginSignup/Domain/SignupInfo.swift
@@ -60,3 +60,10 @@ struct SignupInfosForPassword {
     let venderInfo: SignupVenderInfo?
     let emailInfo: SignupEmailInfo
 }
+
+struct SignupInfosForNickname {
+    let type: SignupType
+    let venderInfo: SignupVenderInfo?
+    let emailInfo: SignupEmailInfo
+    let passwordInfo: SignupPasswordInfo
+}

--- a/Project_Timer/LoginSignup/Domain/SignupInfo.swift
+++ b/Project_Timer/LoginSignup/Domain/SignupInfo.swift
@@ -67,3 +67,11 @@ struct SignupInfosForNickname {
     let emailInfo: SignupEmailInfo
     let passwordInfo: SignupPasswordInfo?
 }
+
+struct SignupInfosForTermOfUse {
+    let type: SignupType
+    let venderInfo: SignupVenderInfo?
+    let emailInfo: SignupEmailInfo
+    let passwordInfo: SignupPasswordInfo?
+    let nicknameInfo: SignupNicknameInfo
+}

--- a/Project_Timer/LoginSignup/Presentation/Login/LoginSelect/LoginSelectModel.swift
+++ b/Project_Timer/LoginSignup/Presentation/Login/LoginSelect/LoginSelectModel.swift
@@ -1,0 +1,57 @@
+//
+//  LoginSelectModel.swift
+//  Project_Timer
+//
+//  Created by Kang Minsang on 2023/11/21.
+//  Copyright © 2023 FDEE. All rights reserved.
+//
+
+import Foundation
+
+class LoginSelectModel: ObservableObject {
+    @Published var contentWidth: CGFloat = .zero
+    @Published var venderInfo: SignupVenderInfo?
+    private(set) var vender: SignupVenderInfo.vender?
+}
+
+// MARK: Action
+extension LoginSelectModel {
+    // 화면크기에 따른 width 크기조정
+    func updateContentWidth(size: CGSize) {
+        switch size.deviceDetailType {
+        case .iPhoneMini:
+            contentWidth = 300
+        case .iPhonePro, .iPhoneMax:
+            contentWidth = abs(size.minLength - 48)
+        default:
+            contentWidth = 400
+        }
+    }
+    
+    func appleLogin() {
+        self.vender = .apple
+        // MARK: login 작업 필요
+        self.venderInfo = SignupVenderInfo(
+            vender: .apple,
+            id: "abcd1234",
+            email: "freedeveloper97@gmail.com"
+        )
+    }
+
+    func googleLogin() {
+        self.vender = .google
+        // MARK: login 작업 필요
+        self.venderInfo = SignupVenderInfo(
+            vender: .google,
+            id: "abcd1234",
+            email: "freedeveloper97@gmail.com"
+        )
+    }
+    
+    var signupInfosForEmail: SignupInfosForEmail {
+        return SignupInfosForEmail(
+            type: self.venderInfo?.email != nil ? .vender : .venderWithEmail,
+            venderInfo: self.venderInfo
+        )
+    }
+}

--- a/Project_Timer/LoginSignup/Presentation/Login/LoginSelect/LoginSelectRoute.swift
+++ b/Project_Timer/LoginSignup/Presentation/Login/LoginSelect/LoginSelectRoute.swift
@@ -9,6 +9,6 @@
 import Foundation
 
 enum LoginSelectRoute {
-    case signupNickname
+    case signupEmail
     case login
 }

--- a/Project_Timer/LoginSignup/Presentation/Login/LoginView/LoginView.swift
+++ b/Project_Timer/LoginSignup/Presentation/Login/LoginView/LoginView.swift
@@ -38,7 +38,10 @@ struct LoginView: View {
                 case .findPassword:
                     Text("findPassword")
                 case .signup:
-                    SignupEmailView(model: SignupEmailModel(infos: (type: .normal, venderInfo: nil)))
+                    let infos = SignupInfosForEmail(type: .normal, venderInfo: nil)
+                    SignupEmailView(
+                        model: SignupEmailModel(infos: infos)
+                    )
                 }
             }
         }

--- a/Project_Timer/LoginSignup/Presentation/Signup/Email/SignupEmailModel.swift
+++ b/Project_Timer/LoginSignup/Presentation/Signup/Email/SignupEmailModel.swift
@@ -65,6 +65,18 @@ class SignupEmailModel: ObservableObject {
                 verificationKey: self.verificationCode)
         )
     }
+    
+    // SignupInfosForNickname 생성 후 반환
+    var infosForNickname: SignupInfosForNickname {
+        return SignupInfosForNickname(
+            type: self.infos.type,
+            venderInfo: self.infos.venderInfo,
+            emailInfo: SignupEmailInfo(
+                email: self.email,
+                verificationKey: self.verificationCode),
+            passwordInfo: nil
+        )
+    }
 }
 
 // MARK: Action

--- a/Project_Timer/LoginSignup/Presentation/Signup/Email/SignupEmailModel.swift
+++ b/Project_Timer/LoginSignup/Presentation/Signup/Email/SignupEmailModel.swift
@@ -10,8 +10,6 @@ import Foundation
 import Combine
 import SwiftUI
 
-typealias SignupSelectInfos = (type: SignupInfo.type, venderInfo: SignupVenderInfo?)
-
 // MARK: State
 class SignupEmailModel: ObservableObject {
     enum Stage {
@@ -19,7 +17,7 @@ class SignupEmailModel: ObservableObject {
         case verificationCode
     }
     
-    let infos: SignupSelectInfos
+    let infos: SignupInfosForEmail
     @Published var contentWidth: CGFloat = .zero
     @Published var focus: SignupTextFieldView.type?
     @Published var validEmail: Bool?
@@ -31,7 +29,7 @@ class SignupEmailModel: ObservableObject {
     @Published var verificationCode: String = ""
     private var verificationKey = ""
     
-    init(infos: SignupSelectInfos) {
+    init(infos: SignupInfosForEmail) {
         self.infos = infos
         // vender email 정보를 기본값으로 설정
         if let email = infos.venderInfo?.email {
@@ -57,9 +55,15 @@ class SignupEmailModel: ObservableObject {
         }
     }
     
-    // emailInfo 생성 후 반환
-    var emailInfo: SignupEmailInfo {
-        return SignupEmailInfo(email: email, verificationKey: verificationKey)
+    // SignupInfosForPassword 생성 후 반환
+    var infosForPassword: SignupInfosForPassword {
+        return SignupInfosForPassword(
+            type: self.infos.type,
+            venderInfo: self.infos.venderInfo,
+            emailInfo: SignupEmailInfo(
+                email: self.email,
+                verificationKey: self.verificationCode)
+            )
     }
 }
 

--- a/Project_Timer/LoginSignup/Presentation/Signup/Email/SignupEmailModel.swift
+++ b/Project_Timer/LoginSignup/Presentation/Signup/Email/SignupEmailModel.swift
@@ -63,7 +63,7 @@ class SignupEmailModel: ObservableObject {
             emailInfo: SignupEmailInfo(
                 email: self.email,
                 verificationKey: self.verificationCode)
-            )
+        )
     }
 }
 

--- a/Project_Timer/LoginSignup/Presentation/Signup/Email/SignupEmailRoute.swift
+++ b/Project_Timer/LoginSignup/Presentation/Signup/Email/SignupEmailRoute.swift
@@ -10,4 +10,5 @@ import Foundation
 
 enum SignupEmailRoute {
     case signupPassword
+    case signupNickname
 }

--- a/Project_Timer/LoginSignup/Presentation/Signup/Email/SignupEmailView.swift
+++ b/Project_Timer/LoginSignup/Presentation/Signup/Email/SignupEmailView.swift
@@ -31,9 +31,10 @@ struct SignupEmailView: View {
             .navigationDestination(for: SignupEmailRoute.self) { destination in
                 switch destination {
                 case .signupPassword:
-                    let prevInfos = model.infos
-                    let emailInfo = model.emailInfo
-                    SignupPasswordView(model: SignupPasswordModel(infos: (prevInfos: prevInfos, emailInfo: emailInfo)))
+                    let infos = model.infosForPassword
+                    SignupPasswordView(
+                        model: SignupPasswordModel(infos: infos)
+                    )
                 }
             }
         }
@@ -160,10 +161,16 @@ struct SignupEmailView: View {
 }
 
 struct SignupEmailView_Previews: PreviewProvider {
+    static let infos = SignupInfosForEmail(type: .normal, venderInfo: nil)
+    
     static var previews: some View {
-        SignupEmailView(model: SignupEmailModel(infos: (type: .normal, venderInfo: nil))).environmentObject(LoginSignupEnvironment())
+        SignupEmailView(
+            model: SignupEmailModel(infos: infos)
+        ).environmentObject(LoginSignupEnvironment())
         
-        SignupEmailView(model: SignupEmailModel(infos: (type: .normal, venderInfo: nil))).environmentObject(LoginSignupEnvironment())
+        SignupEmailView(
+            model: SignupEmailModel(infos: infos)
+        ).environmentObject(LoginSignupEnvironment())
             .environment(\.locale, .init(identifier: "en"))
     }
 }

--- a/Project_Timer/LoginSignup/Presentation/Signup/Email/SignupEmailView.swift
+++ b/Project_Timer/LoginSignup/Presentation/Signup/Email/SignupEmailView.swift
@@ -35,6 +35,11 @@ struct SignupEmailView: View {
                     SignupPasswordView(
                         model: SignupPasswordModel(infos: infos)
                     )
+                case .signupNickname:
+                    let infos = model.infosForNickname
+                    SignupNicknameView(
+                        model: SignupNicknameModel(infos: infos)
+                    )
                 }
             }
         }
@@ -89,7 +94,14 @@ struct SignupEmailView: View {
                             })
                             .onReceive(model.$getVerificationSuccess) { success in
                                 guard success else { return }
-                                environment.navigationPath.append(SignupEmailRoute.signupPassword)
+                                // MARK: infos.type에 따른 분기처리
+                                switch model.infos.type {
+                                case .normal:
+                                    environment.navigationPath.append(SignupEmailRoute.signupPassword)
+                                case .vender, .venderWithEmail:
+                                    environment.navigationPath.append(SignupEmailRoute.signupNickname)
+                                }
+                               
                             }
                             .frame(width: model.contentWidth)
                             Spacer()

--- a/Project_Timer/LoginSignup/Presentation/Signup/Nickname/SignupNicknameModel.swift
+++ b/Project_Timer/LoginSignup/Presentation/Signup/Nickname/SignupNicknameModel.swift
@@ -1,0 +1,17 @@
+//
+//  SignupNicknameModel.swift
+//  Project_Timer
+//
+//  Created by Kang Minsang on 2023/11/21.
+//  Copyright © 2023 FDEE. All rights reserved.
+//
+
+import Foundation
+
+class SignupNicknameModel: ObservableObject {
+    let infos: SignupInfosForNickname
+    
+    init(infos: SignupInfosForNickname) {
+        self.infos = infos
+    }
+}

--- a/Project_Timer/LoginSignup/Presentation/Signup/Nickname/SignupNicknameModel.swift
+++ b/Project_Timer/LoginSignup/Presentation/Signup/Nickname/SignupNicknameModel.swift
@@ -30,6 +30,17 @@ class SignupNicknameModel: ObservableObject {
             return focus == .nickname ? Color.blue : UIColor.placeholderText.toColor
         }
     }
+    
+    // signupInfosForTermOfUse 반환
+    var signupInfosForTermOfUse: SignupInfosForTermOfUse {
+        return SignupInfosForTermOfUse(
+            type: self.infos.type,
+            venderInfo: self.infos.venderInfo,
+            emailInfo: self.infos.emailInfo,
+            passwordInfo: self.infos.passwordInfo,
+            nicknameInfo: SignupNicknameInfo(nickname: self.nickname)
+        )
+    }
 }
 
 extension SignupNicknameModel {

--- a/Project_Timer/LoginSignup/Presentation/Signup/Nickname/SignupNicknameModel.swift
+++ b/Project_Timer/LoginSignup/Presentation/Signup/Nickname/SignupNicknameModel.swift
@@ -7,11 +7,49 @@
 //
 
 import Foundation
+import SwiftUI
 
+// MARK: State
 class SignupNicknameModel: ObservableObject {
     let infos: SignupInfosForNickname
+    @Published var contentWidth: CGFloat = .zero
+    @Published var focus: SignupTextFieldView.type?
+    @Published var validNickname: Bool?
+    
+    @Published var nickname: String = ""
     
     init(infos: SignupInfosForNickname) {
         self.infos = infos
+    }
+    
+    // nicknameTextField underline 컬러
+    var nicknameTintColor: Color {
+        if validNickname == false {
+            return TiTiColor.wrongTextField.toColor
+        } else {
+            return focus == .nickname ? Color.blue : UIColor.placeholderText.toColor
+        }
+    }
+}
+
+extension SignupNicknameModel {
+    // 화면크기에 따른 width 크기조정
+    func updateContentWidth(size: CGSize) {
+        switch size.deviceDetailType {
+        case .iPhoneMini, .iPhonePro, .iPhoneMax:
+            contentWidth = abs(size.minLength - 48)
+        default:
+            contentWidth = 400
+        }
+    }
+    
+    // @FocusState 값변화 반영
+    func updateFocus(to focus: SignupTextFieldView.type?) {
+        self.focus = focus
+    }
+    
+    // nickname done 액션
+    func checkNickname() {
+        validNickname = PredicateChecker.isValidNickname(nickname)
     }
 }

--- a/Project_Timer/LoginSignup/Presentation/Signup/Nickname/SignupNicknameRoute.swift
+++ b/Project_Timer/LoginSignup/Presentation/Signup/Nickname/SignupNicknameRoute.swift
@@ -1,0 +1,13 @@
+//
+//  SignupNicknameRoute.swift
+//  Project_Timer
+//
+//  Created by Kang Minsang on 2023/11/21.
+//  Copyright © 2023 FDEE. All rights reserved.
+//
+
+import Foundation
+
+enum SignupNicknameRoute {
+    case signupTermOfUse
+}

--- a/Project_Timer/LoginSignup/Presentation/Signup/Nickname/SignupNicknameView.swift
+++ b/Project_Timer/LoginSignup/Presentation/Signup/Nickname/SignupNicknameView.swift
@@ -31,6 +31,7 @@ struct SignupNicknameView: View {
             .navigationDestination(for: SignupNicknameRoute.self) { destination in
                 switch destination {
                 case .signupTermOfUse:
+                    let infos = model.signupInfosForTermOfUse
                     Text("SignupTermOfUse")
                 }
             }

--- a/Project_Timer/LoginSignup/Presentation/Signup/Nickname/SignupNicknameView.swift
+++ b/Project_Timer/LoginSignup/Presentation/Signup/Nickname/SignupNicknameView.swift
@@ -9,6 +9,7 @@
 import SwiftUI
 
 struct SignupNicknameView: View {
+    @ObservedObject private var keyboard = KeyboardResponder.shared
     @StateObject private var model: SignupNicknameModel
     
     init(model: SignupNicknameModel) {
@@ -16,7 +17,76 @@ struct SignupNicknameView: View {
     }
     
     var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+        GeometryReader { geometry in
+            ZStack {
+                TiTiColor.firstBackground.toColor
+                    .ignoresSafeArea()
+                
+                ContentView(model: model)
+                    .padding(.bottom, keyboard.keyboardHeight+16)
+            }
+            .onChange(of: geometry.size) { newValue in
+                model.updateContentWidth(size: newValue)
+            }
+            .navigationDestination(for: SignupNicknameRoute.self) { destination in
+                switch destination {
+                case .signupTermOfUse:
+                    Text("SignupTermOfUse")
+                }
+            }
+        }
+        .configureForTextFieldRootView()
+    }
+    
+    struct ContentView: View {
+        @EnvironmentObject var environment: LoginSignupEnvironment
+        @ObservedObject var model: SignupNicknameModel
+        @FocusState private var focus: SignupTextFieldView.type?
+        
+        var body: some View {
+            ZStack {
+                ScrollViewReader { ScrollViewProxy in
+                    ScrollView {
+                        HStack {
+                            Spacer()
+                            VStack {
+                                SignupTitleView(title: "닉네임을 입력해 주세요", subTitle: "12자리 이내 입력해 주세요")
+                                
+                                SignupTextFieldView(type: .nickname, keyboardType: .alphabet, text: $model.nickname, focus: $focus) {
+                                    model.checkNickname()
+                                }
+                                .onChange(of: model.nickname) { newValue in
+                                    model.validNickname = nil
+                                }
+                                SignupTextFieldUnderlineView(color: model.nicknameTintColor)
+                                SignupTextFieldWarning(warning: "영문, 숫자, 또는 10가지 특수문자 내에서 입력해 주세요", visible: model.validNickname == false)
+                                    .id(SignupTextFieldView.type.nickname)
+                            }
+                            .onAppear { // @FocusState 변화 반영
+                                if model.validNickname == nil && model.nickname.isEmpty {
+                                    focus = .nickname
+                                }
+                            }
+                            .onChange(of: focus, perform: { value in
+                                model.updateFocus(to: value)
+                                scroll(ScrollViewProxy, to: value)
+                            })
+                            .onReceive(model.$validNickname, perform: { valid in
+                                if valid == true {
+                                    environment.navigationPath.append(SignupNicknameRoute.signupTermOfUse)
+                                } else {
+                                    focus = .nickname
+                                    scroll(ScrollViewProxy, to: focus)
+                                }
+                            })
+                            .frame(width: model.contentWidth)
+                            Spacer()
+                        }
+                    }
+                    .scrollIndicators(.hidden)
+                }
+            }
+        }
     }
 }
 

--- a/Project_Timer/LoginSignup/Presentation/Signup/Nickname/SignupNicknameView.swift
+++ b/Project_Timer/LoginSignup/Presentation/Signup/Nickname/SignupNicknameView.swift
@@ -1,0 +1,44 @@
+//
+//  SignupNicknameView.swift
+//  Project_Timer
+//
+//  Created by Kang Minsang on 2023/11/21.
+//  Copyright © 2023 FDEE. All rights reserved.
+//
+
+import SwiftUI
+
+struct SignupNicknameView: View {
+    @StateObject private var model: SignupNicknameModel
+    
+    init(model: SignupNicknameModel) {
+        _model = StateObject(wrappedValue: model)
+    }
+    
+    var body: some View {
+        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+    }
+}
+
+struct SignupNicknameView_Previews: PreviewProvider {
+    static let infos = SignupInfosForNickname(
+        type: .normal,
+        venderInfo: nil,
+        emailInfo: SignupEmailInfo(
+            email: "freedeveloper97@gmail.com",
+            verificationKey: "abcd1234"),
+        passwordInfo: SignupPasswordInfo(
+            password: "Abcd1234!")
+    )
+    
+    static var previews: some View {
+        SignupNicknameView(
+            model: SignupNicknameModel(infos: infos))
+        .environmentObject(LoginSignupEnvironment())
+        
+        SignupNicknameView(
+            model: SignupNicknameModel(infos: infos))
+        .environmentObject(LoginSignupEnvironment())
+        .environment(\.locale, .init(identifier: "en"))
+    }
+}

--- a/Project_Timer/LoginSignup/Presentation/Signup/Password/SignupPasswordModel.swift
+++ b/Project_Timer/LoginSignup/Presentation/Signup/Password/SignupPasswordModel.swift
@@ -48,6 +48,17 @@ class SignupPasswordModel: ObservableObject {
             return focus == .password2 ? Color.blue : UIColor.placeholderText.toColor
         }
     }
+    
+    // SignupInfosForNickname 생성 후 반환
+    var infosForNickname: SignupInfosForNickname {
+        return SignupInfosForNickname(
+            type: self.infos.type,
+            venderInfo: self.infos.venderInfo,
+            emailInfo: self.infos.emailInfo,
+            passwordInfo: SignupPasswordInfo(
+                password: self.password)
+        )
+    }
 }
 
 // MARK: Action

--- a/Project_Timer/LoginSignup/Presentation/Signup/Password/SignupPasswordModel.swift
+++ b/Project_Timer/LoginSignup/Presentation/Signup/Password/SignupPasswordModel.swift
@@ -10,8 +10,6 @@ import Foundation
 import SwiftUI
 import Combine
 
-typealias SignupEmailInfos = (prevInfos: SignupSelectInfos, emailInfo: SignupEmailInfo)
-
 // MARK: State
 class SignupPasswordModel: ObservableObject {
     enum Stage {
@@ -19,7 +17,7 @@ class SignupPasswordModel: ObservableObject {
         case password2
     }
     
-    let infos: SignupEmailInfos
+    let infos: SignupInfosForPassword
     @Published var contentWidth: CGFloat = .zero
     @Published var focus: SignupTextFieldView.type?
     @Published var validPassword: Bool?
@@ -29,7 +27,7 @@ class SignupPasswordModel: ObservableObject {
     @Published var password: String = ""
     @Published var password2: String = ""
     
-    init(infos: SignupEmailInfos) {
+    init(infos: SignupInfosForPassword) {
         self.infos = infos
     }
     
@@ -49,11 +47,6 @@ class SignupPasswordModel: ObservableObject {
         } else {
             return focus == .password2 ? Color.blue : UIColor.placeholderText.toColor
         }
-    }
-    
-    // passwordInfo 생성 후 반환
-    var passwordInfo: SignupPasswordInfo {
-        return SignupPasswordInfo(password: password)
     }
 }
 

--- a/Project_Timer/LoginSignup/Presentation/Signup/Password/SignupPasswordView.swift
+++ b/Project_Timer/LoginSignup/Presentation/Signup/Password/SignupPasswordView.swift
@@ -31,7 +31,10 @@ struct SignupPasswordView: View {
             .navigationDestination(for: SignupPasswordRoute.self) { destination in
                 switch destination {
                 case .signupNickname:
-                    Text("SignupNickName")
+                    let infos = self.model.infosForNickname
+                    SignupNicknameView(
+                        model: SignupNicknameModel(infos: infos)
+                    )
                 }
             }
         }

--- a/Project_Timer/LoginSignup/Presentation/Signup/Password/SignupPasswordView.swift
+++ b/Project_Timer/LoginSignup/Presentation/Signup/Password/SignupPasswordView.swift
@@ -122,10 +122,16 @@ struct SignupPasswordView: View {
 }
 
 struct SignupPasswordView_Previews: PreviewProvider {
-    static let prevInfos: SignupSelectInfos = (type: .normal, venderInfo: nil)
-    static let emailInfo: SignupEmailInfo = SignupEmailInfo(email: "freedeveloper97@gmail.com", verificationKey: "abcd1234")
+    static let infos = SignupInfosForPassword(type: .normal, venderInfo: nil, emailInfo: SignupEmailInfo(email: "freedeveloper97@gmail.com", verificationKey: "abcd1234"))
     
     static var previews: some View {
-        SignupPasswordView(model: SignupPasswordModel(infos: (prevInfos: prevInfos, emailInfo: emailInfo))).environmentObject(LoginSignupEnvironment())
+        SignupPasswordView(
+            model: SignupPasswordModel(infos: infos)
+        ).environmentObject(LoginSignupEnvironment())
+        
+        SignupPasswordView(
+            model: SignupPasswordModel(infos: infos)
+        ).environmentObject(LoginSignupEnvironment())
+            .environment(\.locale, .init(identifier: "en"))
     }
 }

--- a/Project_Timer/LoginSignup/Presentation/Signup/Password/SignupPasswordView.swift
+++ b/Project_Timer/LoginSignup/Presentation/Signup/Password/SignupPasswordView.swift
@@ -53,7 +53,7 @@ struct SignupPasswordView: View {
                         HStack {
                             Spacer()
                             VStack(alignment: .leading, spacing: 0) {
-                                SignupTitleView(title: "비밀번호를 입력해주세요", subTitle: "8자리 이상 비밀번호를 입력해주세요")
+                                SignupTitleView(title: "비밀번호를 입력해 주세요", subTitle: "8자리 이상 비밀번호를 입력해 주세요")
                                 
                                 SignupSecureFieldView(type: .password, keyboardType: .alphabet, text: $model.password, focus: $focus) {
                                     model.checkPassword()


### PR DESCRIPTION
### 개요
- Issue:  #117 
- Tech Spec: [회원 관리 기능 개발](https://timertiti.notion.site/4cb5c74f656e4bf784cff130213fd086?pvs=4)
- Figma: [로그인 프로세스](https://www.figma.com/file/T8hsaAguFkPytBiNMOOw03/Develop?type=design&node-id=670-9559&mode=design)

---

### 변경사항
- [x] 화면별 의존성주입이 필요한 SignupInfos 생성 및 리펙토링
- [x] 로그인 선택창 -> 닉네임 입력화면 전환 가능하도록 의존성주입 리펙토링
- [x] 비밀번호 입력창 -> 닉네임 입력화면 전환 가능하도록 의존성주입 리펙토링
- [x] LoginSelectModel 생성
- [x] SignupNicknameView, Model 생성 및 구현

| 일반 회원가입 화면 전환 | 소셜 회원가입 화면 전환 |
| -------- | -------- |
| <img src="https://github.com/TimerTiTi/TiTi_iOS/assets/65349445/f81a3114-5416-466f-986b-9c2e46ca61ad"> | <img src="https://github.com/TimerTiTi/TiTi_iOS/assets/65349445/91541bcb-357f-4522-b5a5-6c150f3165d1"> |

### 회원가입 화면전환에 따른 의존성 주입
화면별로 사용자가 입력한 데이터를 적층하여 의존성주입을 위한 구조체를 생성하여 전달하는 방식으로 구현
다만 화면전환 순서가 다를 수 있기에 `optional`한 값을 전달하는 식으로 구현
```swift
// MARK: Infos
struct SignupInfosForEmail {
    let type: SignupType
    let venderInfo: SignupVenderInfo?
}

struct SignupInfosForPassword {
    let type: SignupType
    let venderInfo: SignupVenderInfo?
    let emailInfo: SignupEmailInfo
}

struct SignupInfosForNickname {
    let type: SignupType
    let venderInfo: SignupVenderInfo?
    let emailInfo: SignupEmailInfo
    let passwordInfo: SignupPasswordInfo?
}

struct SignupInfosForTermOfUse {
    let type: SignupType
    let venderInfo: SignupVenderInfo?
    let emailInfo: SignupEmailInfo
    let passwordInfo: SignupPasswordInfo?
    let nicknameInfo: SignupNicknameInfo
}
```

### 의존성주입 및 화면 전환에 대한 고민
TiTi의 경우 소셜로그인, 또는 일반 회원가입 절차를 지원한다.
따라서 상황에 따라 회원가입 절차의 `화면 전환 순서`가 달랐기에 `의존성 주입`에 대한 고민이 필요했다.
- 소셜로그인 선택 -> 이메일 입력 -> `닉네임 화면` 전환
- 로그인 화면 내 회원가입 선택 -> 이메일 입력 -> 비밀번호 입력 -> `닉네임 화면` 전환

#### 이메일 입력 화면의 의존성 주입
소셜로그인을 통해 전환되는 경우 venderInfo를 지니며, 로그인 화면에서 전환되는 경우 nil 값인 구조를 통해 구현했다.
소셜로그인 선택 -> 이메일 입력 표시의 경우
```swift
var signupInfosForEmail: SignupInfosForEmail {
    return SignupInfosForEmail(
        type: self.venderInfo?.email != nil ? .vender : .venderWithEmail,
        venderInfo: self.venderInfo
    )
}
```
```swift
let infos = model.signupInfosForEmail
SignupEmailView(
    model: SignupEmailModel(infos: infos)
)
```
회원가입 선택 -> 이메일 입력 표시의 경우
```swift
let infos = SignupInfosForEmail(type: .normal, venderInfo: nil)
SignupEmailView(
    model: SignupEmailModel(infos: infos)
)
```

#### 이메일 입력 화면의 화면전환 분기처리
이메일 입력 화면에서 닉네임 입력 화면, 또는 비밀번호 입력 화면으로 전환 분기처리가 필요하였다.
이전화면에서 의존성주입된 SignupType 값에 따라 분기처리 하여 구현하였다.
```swift
// SignupInfosForPassword 생성 후 반환
var infosForPassword: SignupInfosForPassword {
    return SignupInfosForPassword(
        type: self.infos.type,
        venderInfo: self.infos.venderInfo,
        emailInfo: SignupEmailInfo(
            email: self.email,
            verificationKey: self.verificationCode)
    )
}

// SignupInfosForNickname 생성 후 반환
var infosForNickname: SignupInfosForNickname {
    return SignupInfosForNickname(
        type: self.infos.type,
        venderInfo: self.infos.venderInfo,
        emailInfo: SignupEmailInfo(
            email: self.email,
            verificationKey: self.verificationCode),
        passwordInfo: nil
    )
}
```
```swift
.onReceive(model.$getVerificationSuccess) { success in
    guard success else { return }
    // MARK: infos.type에 따른 분기처리
    switch model.infos.type {
    case .normal:
        environment.navigationPath.append(SignupEmailRoute.signupPassword)
    case .vender, .venderWithEmail:
        environment.navigationPath.append(SignupEmailRoute.signupNickname)
    }
}
```
```swift
.navigationDestination(for: SignupEmailRoute.self) { destination in
    switch destination {
    case .signupPassword:
        let infos = model.infosForPassword
        SignupPasswordView(
            model: SignupPasswordModel(infos: infos)
        )
    case .signupNickname:
        let infos = model.infosForNickname
        SignupNicknameView(
            model: SignupNicknameModel(infos: infos)
        )
    }
}
```