### PR TITLE
Log 화면에 비어 있는 Dailys가 노출되는 버그 해결

### DIFF
--- a/Project_Timer.xcodeproj/project.pbxproj
+++ b/Project_Timer.xcodeproj/project.pbxproj
@@ -3034,14 +3034,6 @@
 				minimumVersion = 2.0.0;
 			};
 		};
-		87861F18284D917C00227731 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/firebase/firebase-ios-sdk";
-			requirement = {
-				branch = master;
-				kind = branch;
-			};
-		};
 		87910826283876DD005D7B10 /* XCRemoteSwiftPackageReference "Alamofire" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/Alamofire/Alamofire";

--- a/Project_Timer.xcodeproj/project.pbxproj
+++ b/Project_Timer.xcodeproj/project.pbxproj
@@ -2088,7 +2088,6 @@
 				8773AF4B27DCB59400739A09 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
 				8773AF5027DCB5D100739A09 /* XCRemoteSwiftPackageReference "FSCalendar" */,
 				87910826283876DD005D7B10 /* XCRemoteSwiftPackageReference "Alamofire" */,
-				87861F18284D917C00227731 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
 				8760FCB529541B88000BCCD1 /* XCRemoteSwiftPackageReference "SwiftKeychainWrapper" */,
 				876C3B092B10361E002A5132 /* XCRemoteSwiftPackageReference "GoogleSignIn-iOS" */,
 				87D4DCE92BA6B04B00BB5AAB /* XCRemoteSwiftPackageReference "lottie-ios" */,
@@ -2673,9 +2672,11 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = Project_Timer/Project_TimerDevelop.entitlements;
-				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 2;
-				DEVELOPMENT_TEAM = 2C96RNDN63;
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 2C96RNDN63;
 				"ENABLE_HARDENED_RUNTIME[sdk=macosx*]" = YES;
 				INFOPLIST_FILE = Project_Timer/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
@@ -2686,6 +2687,8 @@
 				MARKETING_VERSION = 7.17.2;
 				PRODUCT_BUNDLE_IDENTIFIER = "$(APP_BUNDLE_ID)";
 				PRODUCT_NAME = "$(APP_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = profile_grin_dev;
 				SUPPORTS_MACCATALYST = YES;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_VERSION = 5.0;
@@ -2701,9 +2704,11 @@
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CODE_SIGN_ENTITLEMENTS = widgetExtension.entitlements;
-				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 2C96RNDN63;
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 2C96RNDN63;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = widget/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = widget;
@@ -2717,6 +2722,8 @@
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.FDEE.TiTi.dev.widget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = profile_grin_dev_widget;
 				SKIP_INSTALL = YES;
 				SUPPORTS_MACCATALYST = YES;
 				SWIFT_EMIT_LOC_STRINGS = YES;

--- a/Project_Timer/AppDelegate.swift
+++ b/Project_Timer/AppDelegate.swift
@@ -30,14 +30,13 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
             self.configureGoogleAdmob()
         }
         
+        self.updateToLastestVersion()
         self.configureNotificationCenterAddObserver()
         self.configureMacCatalyst()
-        self.configureSharedUserDefaults()
         self.configureWidget()
         
         self.checkSignined()
         self.checkNotification()
-        self.checkEmptyDailys()
         
         return true
     }
@@ -202,14 +201,6 @@ extension AppDelegate {
         #endif
     }
     
-    private func configureSharedUserDefaults() {
-        /// UserDefaults.standard -> shared 반영
-        if Versions.check(forKey: .updateSharedUserDefaultsCheckVer) {
-            UserDefaults.updateShared()
-            Versions.update(forKey: .updateSharedUserDefaultsCheckVer)
-        }
-    }
-    
     private func configureWidget() {
         WidgetCenter.shared.reloadTimelines(ofKind: "CalendarWidget")
     }
@@ -250,11 +241,7 @@ extension AppDelegate {
         }
     }
     
-    private func checkEmptyDailys() {
-        guard let value = UserDefaultsManager.get(forKey: .didRemoveEmptyDailys) as? Bool, value else {
-            RecordsManager.shared.dailyManager.removeEmptyDailys()
-            UserDefaultsManager.set(to: true, forKey: .didRemoveEmptyDailys)
-            return
-        }
+    private func updateToLastestVersion() {
+        Versions.update()
     }
 }

--- a/Project_Timer/AppDelegate.swift
+++ b/Project_Timer/AppDelegate.swift
@@ -37,6 +37,7 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
         
         self.checkSignined()
         self.checkNotification()
+        self.checkEmptyDailys()
         
         return true
     }
@@ -246,6 +247,14 @@ extension AppDelegate {
                     print(networkError.alertMessage)
                 }
             }
+        }
+    }
+    
+    private func checkEmptyDailys() {
+        guard let value = UserDefaultsManager.get(forKey: .didRemoveEmptyDailys) as? Bool, value else {
+            RecordsManager.shared.dailyManager.removeEmptyDailys()
+            UserDefaultsManager.set(to: true, forKey: .didRemoveEmptyDailys)
+            return
         }
     }
 }

--- a/Project_Timer/Core/Global/SingletonClass/DailyManager.swift
+++ b/Project_Timer/Core/Global/SingletonClass/DailyManager.swift
@@ -43,8 +43,12 @@ final class DailyManager {
 
     func modifyDaily(_ newDaily: Daily) {
         if let index = self.dailys.firstIndex(where: { $0.day == newDaily.day }) {
-            self.dailys[index] = newDaily
-        } else {
+            if newDaily.totalTime == 0 {
+                self.dailys.remove(at: index)
+            } else {
+                self.dailys[index] = newDaily
+            }
+        } else if newDaily.totalTime > 0 {
             self.dailys.append(newDaily)
             self.dailys.sort(by: { $0.day < $1.day })
         }

--- a/Project_Timer/Core/Global/SingletonClass/DailyManager.swift
+++ b/Project_Timer/Core/Global/SingletonClass/DailyManager.swift
@@ -65,9 +65,7 @@ final class DailyManager {
     }
     
     func removeEmptyDailys() {
-        dailys = dailys.filter { daily in
-            return daily.totalTime > 0
-        }
+        dailys = dailys.filter { $0.totalTime > 0 }
         self.saveDailys()
     }
 }

--- a/Project_Timer/Core/Global/SingletonClass/DailyManager.swift
+++ b/Project_Timer/Core/Global/SingletonClass/DailyManager.swift
@@ -9,6 +9,7 @@
 import Foundation
 
 final class DailyManager {
+    static let shared = DailyManager()
     static let dailysFileName: String = "dailys.json"
     var dailys: [Daily] = [] {
         didSet {
@@ -16,6 +17,8 @@ final class DailyManager {
         }
     }
     var dates: [Date] = []
+    
+    private init() {}
     
     func loadDailys() {
         self.dailys = Storage.retrive(Self.dailysFileName, from: .documents, as: [Daily].self) ?? []

--- a/Project_Timer/Core/Global/SingletonClass/DailyManager.swift
+++ b/Project_Timer/Core/Global/SingletonClass/DailyManager.swift
@@ -63,6 +63,13 @@ final class DailyManager {
         self.dailys.sort(by: { $0.day < $1.day })
         self.saveDailys()
     }
+    
+    func removeEmptyDailys() {
+        dailys = dailys.filter { daily in
+            return daily.totalTime > 0
+        }
+        self.saveDailys()
+    }
 }
 
 extension DailyManager {

--- a/Project_Timer/Core/Global/SingletonClass/RecordsManager.swift
+++ b/Project_Timer/Core/Global/SingletonClass/RecordsManager.swift
@@ -10,7 +10,7 @@ import Foundation
 
 final class RecordsManager {
     static let shared = RecordsManager()
-    var dailyManager = DailyManager()
+    var dailyManager = DailyManager.shared
     var taskManager = TaskManager()
     var recordTimes = RecordTimes()
     var currentDaily = Daily()

--- a/Project_Timer/Core/Global/SingletonClass/UserDefaultsManager.swift
+++ b/Project_Timer/Core/Global/SingletonClass/UserDefaultsManager.swift
@@ -47,6 +47,8 @@ struct UserDefaultsManager {
         case languageCode
         // Notification
         case notificationPassDay
+        // daily
+        case didRemoveEmptyDailys
     }
     
     static func set<T>(to: T, forKey: Self.Keys) {

--- a/Project_Timer/Core/Global/SingletonClass/UserDefaultsManager.swift
+++ b/Project_Timer/Core/Global/SingletonClass/UserDefaultsManager.swift
@@ -47,8 +47,8 @@ struct UserDefaultsManager {
         case languageCode
         // Notification
         case notificationPassDay
-        // daily
-        case didRemoveEmptyDailys
+        
+        case lastUpdateVersion
     }
     
     static func set<T>(to: T, forKey: Self.Keys) {

--- a/Project_Timer/Core/Global/Versions.swift
+++ b/Project_Timer/Core/Global/Versions.swift
@@ -17,7 +17,7 @@ struct Versions {
     /// useage 버튼 추가시 key 추가
     private enum Keys: String, CaseIterable {
         case updateSharedUserDefaultsCheckVer = "7.14"
-        case removeEmptyDailys = "7.17"
+        case removeEmptyDailys = "7.17.3"
     }
     
     static func update() {


### PR DESCRIPTION
### 리뷰 요청
- [ ] 🙋 꼭 리뷰를 받고 싶어요!
- [ ] 리뷰 긴급도: D-x

### 개요
- Issue:  [link](https://github.com/orgs/TimerTiTi/projects/12/views/1?sliceBy%5Bvalue%5D=TimerTiTi%2FTiTi_iOS&pane=issue&itemId=64584355)
- Tech Spec: [link](https://www.notion.so/timertiti/Log-Daily-525a4cba7d974432af5624bdaa036de4?pvs=4)
- Figma: ❌

---

### 변경사항
- [x] DailyManager을 Singleton으로 변경
- [x] Log화면에서 편집시 Empty Daily제거
- [x] AppDelegate에서 Empty Dailys 제거 작업
- [x] Versions로 Empty Dailys 제거 작업하도록 변경
---

### DailyManager을 Singleton으로 변경
- `DailyManager`는 현재 `RecordsManager`에서만 생성되어 사용하고 있음
- 그러나 실제로는 어디서나 생성 가능한 구조
- 만약, `DailyManager`가 다른 곳에서 인스턴스가 생성되어 사용된다면 데이터의 sync가 맞지 않는 문제가 발생할 수 있음
- 이를 방지하고자 `DailyManager`를 Singleton으로 변경함

### Versions로 Empty Dailys 제거 작업하도록 변경
- Empty Dailys 제거 작업: 이미 만들어진 Empty Dailys를 제거 하는 작업이 1회 필요함
- 1회성으로 동작하는 로직을 관리하기 위해 UserDefaults를 사용하면 메모리가 낭비됨 
-> 1회 동작 이후에 UserDefaults의 값을 읽는것 외에 값을 관리하지 않기 때문
- Versions 객체를 만들어 UserDefaults 값 하나로 1회성으로 동작하는 로직을 관리하도록 함

```
1. 앱진입시 Versions.update()
2. lastUpdateVersion(UserDefaults)를 통해 앱업데이트 직전의 버전 값을 가져옴
3. 1회 동작이 필요한 로직들이 업데이트 된 시점과 lastUpdateVersion을 비교하여 동작이 필요한지 판별
4. 모든 로직을 판별하여 업데이트한 후 lastUpdateVersion을 현재 버전으로 갱신
```


---
### Screenshot

**- BEFORE**
기록이 없지만 해당 날짜에 점이 찍혀 있습니다.
<img src="https://github.com/TimerTiTi/TiTi_iOS/assets/63739061/ffcefbef-c597-42b5-a1f6-725800b68432"  width="400" />

**- AFTER**
기록을 지우면 점이 사라집니다. (정확한 이해를 위해 영상 첨부)

https://github.com/TimerTiTi/TiTi_iOS/assets/63739061/6f2a39b9-990c-44e7-8398-823d933e40b9


