### PR TITLE
feat api error 발생시 loading indicator 제거되도록 수정

### DIFF
--- a/Project_Timer/Core/Design System/Component/View/LoadingIndicator.swift
+++ b/Project_Timer/Core/Design System/Component/View/LoadingIndicator.swift
@@ -42,9 +42,10 @@ struct LoadingIndicator {
     }
     
     static func hideLoading() {
-        DispatchQueue.main.async {
-            guard let window = UIApplication.shared.windows.last else { return }
-            window.subviews.filter({ $0 is UIActivityIndicatorView }).forEach { $0.removeFromSuperview() }
+        guard let window = UIApplication.shared.windows.last else { return }
+        window.subviews.filter({ $0 is UIActivityIndicatorView }).forEach {
+            print("remove loading indicator")
+            $0.removeFromSuperview()
         }
     }
 }

--- a/Project_Timer/Present/Setting/Service/SettingTiTiLab/TestServer/SyncDailys/SyncDailysVC.swift
+++ b/Project_Timer/Present/Setting/Service/SettingTiTiLab/TestServer/SyncDailys/SyncDailysVC.swift
@@ -88,14 +88,14 @@ extension SyncDailysVC {
     }
     
     private func bindLoading() {
-        self.viewModel?.$loading
+        self.viewModel?.$isLoading
             .receive(on: DispatchQueue.main)
-            .sink(receiveValue: { [weak self] loading in
-                switch loading {
-                case true:
+            .dropFirst()
+            .sink(receiveValue: { [weak self] isLoading in
+                if isLoading {
                     let loadingText = self?.viewModel?.loadingText?.rawValue
                     LoadingIndicator.showLoading(text: loadingText)
-                case false:
+                } else {
                     LoadingIndicator.hideLoading()
                 }
             })
@@ -105,14 +105,11 @@ extension SyncDailysVC {
     private func bindError() {
         self.viewModel?.$alert
             .receive(on: DispatchQueue.main)
+            .dropFirst()
+            .compactMap { $0 }
             .sink(receiveValue: { [weak self] error in
                 LoadingIndicator.hideLoading()
-                guard let error = error else { return }
-                self?.showAlertWithOKAfterHandler(title: error.title, text: error.text, completion: {
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-                        LoadingIndicator.hideLoading()
-                    }
-                })
+                self?.showAlertWithOK(title: error.title, text: error.text)
             })
             .store(in: &self.cancellables)
     }

--- a/Project_Timer/Present/Setting/Service/SettingTiTiLab/TestServer/SyncDailys/SyncDailysVM.swift
+++ b/Project_Timer/Present/Setting/Service/SettingTiTiLab/TestServer/SyncDailys/SyncDailysVM.swift
@@ -78,6 +78,7 @@ extension SyncDailysVM {
             case .success(_):
                 self?.getDailys()
             case .failure(let error):
+                self?.loading = false
                 switch error {
                 case .CLIENTERROR(let message):
                     if let message = message {
@@ -102,6 +103,7 @@ extension SyncDailysVM {
             case .success(_):
                 self?.getSyncLog(afterUploaded: true)
             case .failure(let error):
+                self?.loading = false
                 switch error {
                 case .CLIENTERROR(let message):
                     if let message = message {
@@ -154,6 +156,7 @@ extension SyncDailysVM {
                 self?.loading = false
                 self?.getSyncLog(afterUploaded: true)
             case .failure(let error):
+                self?.loading = false
                 switch error {
                 case .CLIENTERROR(let message):
                     if let message = message {
@@ -182,6 +185,7 @@ extension SyncDailysVM {
                 }
                 self?.syncLog = syncLog
             case .failure(let error):
+                self?.loading = false
                 switch error {
                 case .CLIENTERROR(let message):
                     if let message = message {


### PR DESCRIPTION
### 리뷰 요청
- [x] 🙋 꼭 리뷰를 받고 싶어요!
- [x] 리뷰 긴급도: D-7 (10/12)

### 변경사항
- [x] Sync Dailys 화면 내에서 api 요청시 error 가 발생했을 때 loading indicator가 제거되도록 수정

### 문제상황 분석
api error가 발생되면 viewController 에서 `bindError()` 를 통해 `alert` 값 변화를 감지하여 `showAlertWithOKAfterHandler()` 함수를 통해 Alert 가 표시됩니다.
Alert 내에서 "확인"을 클릭하고 나서 completion 을 통해 `LoadingIndicator.hideLoading()` 가 실행되어 Loading Indicator가 사라져야 했습니다.
하지만 실제로는 loading indicator가 사라지지 않았고, 디버깅을 통해 window 상에 loadingIndicator가 없는 것이 문제였다는 것을 알 수 있었습니다.
```swift
static func hideLoading() {
    DispatchQueue.main.async {
        guard let window = UIApplication.shared.windows.last else { return } // 여기서 return 됌
        window.subviews.filter({ $0 is UIActivityIndicatorView }).forEach { $0.removeFromSuperview() }
    }
}
```
이는 현재 표시중인 window가 loading indicator를 지니고 있는 window가 아니라 system 에서 표시된 alert 로 인지되는 문제였습니다.

### 문제상황 해결
system alert로 인해 window 내 alert가 없는 window가 될 수 있다는 점을 고려하여 alert를 띄우기 전에 loading indicator를 먼저 제거하고자 하였습니다.
또한, error로 인해 loading indicator를 hide 시키는 부분을 오로지 bindError() 메소드 내에서만 관여하도록 viewModel 로직을 수정하였습니다.
```swift
private func bindError() {
    self.viewModel?.$alert
        .receive(on: DispatchQueue.main)
        .dropFirst()
        .compactMap { $0 }
        .sink(receiveValue: { [weak self] error in
            LoadingIndicator.hideLoading() // 1. alert 표시 전에 먼저 loading indicator 제거
            self?.showAlertWithOK(title: error.title, text: error.text) // 2. loading indicator 제거된 후에 alert 표시
        })
        .store(in: &self.cancellables)
}
```
해당 코드로 인해 1. -> 2. 순차적으로 실행되어 loading indicator가 제거된 이후 alert가 표시되어야 했으나, 여전히 loading indicator는 사라지지 않았습니다.

이 현상을 더욱 분석한 결과 hideLoading() 메소드 내에서 `DispatchQueue.main.async` 로 감싸는 것이 문제가 된다는 것을 발견하였습니다.
```swift
static func hideLoading() {
    DispatchQueue.main.async { // 이 부분을 제거하니 문제가 해결
        guard let window = UIApplication.shared.windows.last else { return }
        window.subviews.filter({ $0 is UIActivityIndicatorView }).forEach { $0.removeFromSuperview() }
    }
}
```
이를 토대로, main thread 를 사용하기 위한 DispatchQueue.main.async 내부, 외부간의 작업이 순차적으로 이뤄지지 않을 수 있다는 점을 알게되었고, 왜 그랬는지는 추가로 공부해보고자 합니다.

최종적으로, 1. -> 2. 순서로 함수를 호출하며, hideLoading() 메소드 내에서 DispatchQueue.main.async 를 제거하여 문제가 해결되었습니다. 
```swift
static func hideLoading() {
    guard let window = UIApplication.shared.windows.last else { return }
    window.subviews.filter({ $0 is UIActivityIndicatorView }).forEach {
        print("remove loading indicator")
        $0.removeFromSuperview()
    }
}
```

### 스크린샷
문제 상황

https://github.com/user-attachments/assets/63bdb646-a365-4f72-a5b7-8aeeba1f6ba0

문제가 해결된 상황

https://github.com/user-attachments/assets/011d0dbc-9614-4232-bf06-87a9b2ef982d

정상적인 경우

https://github.com/user-attachments/assets/c3c8ee41-ae17-47fe-804e-f1488bc2e64b